### PR TITLE
Expose option to specify a custom hybridization model

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ design.py [dataset] [dataset ...]
 Each `dataset` can be a path to a FASTA file. If you [downloaded](#downloading-viral-sequence-data) viral sequence data, it can also simply be a label for one of [350+ viral datasets](./catch/datasets/README.md) (e.g., `hiv1` or `zika`) distributed as part of this package.
 Each of these datasets includes all available whole genomes (genome neighbors) in [NCBI's viral genome data](https://www.ncbi.nlm.nih.gov/genome/viruses/) that have human as a host, for one or more species, as of Sep. 2017.
 
-Below are some commonly used arguments to `design.py`:
+Below is a summary of some useful arguments to `design.py`:
 
 * `-pl PROBE_LENGTH`/`-ps PROBE_STRIDE`: Design probes to be PROBE_LENGTH nt long, and generate candidate probes using a stride of PROBE_STRIDE nt.
 (Default: 100 and 50.)
@@ -116,6 +116,10 @@ Probes are designed such that each `dataset` should be captured by probes that a
 * `--add-adapters`: Add PCR adapters to the ends of each probe sequence.
 This selects adapters to add to probe sequences so as to minimize overlap among probes that share an adapter, allowing probes with the same adapter to be amplified together.
 (See `--adapter-a` and `--adapter-b` too.)
+* `--custom-hybridization-fn PATH FN`: Specify a function, for CATCH to dynamically load, that implements a custom model of hybridization between a probe and target sequence.
+See `design.py --help` for details on the expected input and output of this function.
+If not set, CATCH uses its default model of hybridization based on `-m/--mismatches`, `-l/--lcf-thres`, and `--island-of-exact-match`.
+(Relatedly, see `--custom-hybridization-fn-tolerant`.)
 * `--filter-with-lsh-hamming FILTER_WITH_LSH_HAMMING`/`--filter-with-lsh-minhash FILTER_WITH_LSH_MINHASH`: Use locality-sensitive hashing to reduce the space of candidate probes.
 This can significantly improve runtime and memory requirements when the input is especially large and diverse.
 See `design.py --help` for details on using these options and downsides.

--- a/catch/filter/adapter_filter.py
+++ b/catch/filter/adapter_filter.py
@@ -109,6 +109,7 @@ import logging
 
 from catch.filter.base_filter import BaseFilter
 from catch import probe
+from catch.utils import dynamic_load
 from catch.utils import interval
 
 __author__ = 'Hayden Metsky <hayden@mit.edu>'
@@ -126,6 +127,7 @@ class AdapterFilter(BaseFilter):
                  mismatches,
                  lcf_thres,
                  island_of_exact_match=0,
+                 custom_cover_range_fn=None,
                  kmer_probe_map_k=20):
         """
         Args:
@@ -141,6 +143,18 @@ class AdapterFilter(BaseFilter):
             island_of_exact_match: for a probe to hybridize to a sequence,
                 require that there be an exact match of length at least
                 'island_of_exact_match'
+            custom_cover_range_fn: if set, tuple (path, fn) where path gives
+                a path to a Python module and fn gives the name of a function
+                in that module. This function is dynamically loaded and used
+                to determine whether a probe will hybridize to a region of
+                target sequence (and what portion will hybridize). The
+                function must accept the same arguments as the function
+                returned by
+                probe.probe_covers_sequence_by_longest_common_substring()
+                and return the same value. When set, the parameters
+                'mismatches', 'lcf_thres', and 'island_of_exact_match'
+                are ignored (even if their values are default values)
+                because they are only used in the default cover_range_fn
             kmer_probe_map_k: in calls to probe.construct_kmer_probe_map...,
                 uses this value as min_k and k
         """
@@ -151,12 +165,27 @@ class AdapterFilter(BaseFilter):
 
         self.adapter_a_5end, self.adapter_a_3end = adapter_a
         self.adapter_b_5end, self.adapter_b_3end = adapter_b
-        self.mismatches = mismatches
-        self.lcf_thres = lcf_thres
-        self.cover_range_fn = \
-            probe.probe_covers_sequence_by_longest_common_substring(
-                mismatches=mismatches, lcf_thres=lcf_thres,
-                island_of_exact_match=island_of_exact_match)
+
+        if custom_cover_range_fn is not None:
+            # Use a custom function to determine whether a probe hybridizes
+            # to a region of target sequence (and what part hybridizes),
+            # rather than the default model. Ignore the given values for
+            # mismatches and lcf_thres (which may be default values) because
+            # these are only relevant for the default model
+            self.mismatches, self.lcf_thres = None, None
+
+            # Dynamically load the function
+            fn_path, fn_name = custom_cover_range_fn
+            self.cover_range_fn = dynamic_load.load_function_from_path(
+                fn_path, fn_name)
+        else:
+            self.mismatches = mismatches
+            self.lcf_thres = lcf_thres
+            # Construct a function using the default model of hybridization
+            self.cover_range_fn = \
+                probe.probe_covers_sequence_by_longest_common_substring(
+                    mismatches, lcf_thres, island_of_exact_match)
+
         self.kmer_probe_map_k = kmer_probe_map_k
 
     def _votes_in_sequence(self, probes, sequence):

--- a/catch/filter/tests/input/custom_cover_range_fn.py
+++ b/catch/filter/tests/input/custom_cover_range_fn.py
@@ -1,0 +1,14 @@
+"""Functions to use in testing custom_cover_range_fn."""
+
+def covers_abc(probe_seq, sequence, kmer_start, kmer_end,
+                       full_probe_len, full_sequence_len):
+    # probe_seq is an array; sequence is a str
+    probe_seq = ''.join(probe_seq)
+
+    # If 'ABC' is in the probe and sequence, this says that the
+    # probe covers the 'ABC' (and that substring only)
+    if 'ABC' in probe_seq and 'ABC' in sequence:
+        i = sequence.index('ABC')
+        return (i, i + len('ABC'))
+    else:
+        return None

--- a/catch/probe.py
+++ b/catch/probe.py
@@ -519,6 +519,11 @@ def construct_kmer_probe_map_to_find_probe_covers(probes,
     If the "pigeonhole" function fails because it requires too small a
     value for k, then this resorts to calling the "random" function.
 
+    Note that mismatches and/or lcf_thres can be None, in which case the
+    "random" method is always used. This is useful, for example, if using
+    a custom function to determine whether a probe hybridizes to a target,
+    in which case the parameters mismatches and lcf_thres are not meaningful.
+
     Args:
         probes: list of probes from which to construct the map
         mismatches: number of mismatches that will be tolerated when
@@ -551,7 +556,8 @@ def construct_kmer_probe_map_to_find_probe_covers(probes,
             probe_lengths_differ = True
             break
 
-    if probe_lengths_differ or lcf_thres < probe_length:
+    if (mismatches is None or lcf_thres is None or
+            probe_lengths_differ or lcf_thres < probe_length):
         # Use the random method with its default values for k and
         # num_kmers_per_probe
         return _construct_rand_kmer_probe_map(

--- a/catch/utils/dynamic_load.py
+++ b/catch/utils/dynamic_load.py
@@ -1,0 +1,55 @@
+"""Functions for dynamically loading modules and functions.
+"""
+
+import importlib
+import os
+
+__author__ = 'Hayden Metsky <hayden@mit.edu>'
+
+
+def load_module_from_path(path):
+    """Load Python module in the given path.
+
+    Args:
+        path: path to .py file
+
+    Returns:
+        Python module (before returning, this also executes
+        the module)
+    """
+    path = os.path.abspath(path)
+
+    # Use the filename (without extension) as the module name
+    _, filename = os.path.split(path)
+    module_name, _ = os.path.splitext(filename)
+
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+
+    # Execute the module
+    spec.loader.exec_module(module)
+
+    return module
+
+
+def load_function_from_path(path, fn_name):
+    """Load Python function in a module at the given path.
+
+    Args:
+        path: path to .py file
+        fn_name: name of function in the module
+
+    Returns:
+        Python function
+
+    Raises:
+        Exception if the module at path does not contain a function
+        with name fn_name
+    """
+    module = load_module_from_path(path)
+
+    if not hasattr(module, fn_name):
+        raise Exception(("Module at %s does not contain function %s" %
+            (path, fn_name)))
+
+    return getattr(module, fn_name)

--- a/catch/utils/tests/input/test_module.py
+++ b/catch/utils/tests/input/test_module.py
@@ -1,0 +1,8 @@
+"""Module to test dynamic loading."""
+
+# Define a variable to check its value
+testvar = 'testval'
+
+# Define a function to check its loading and execution
+def sum(a, b):
+    return a + b

--- a/catch/utils/tests/test_dynamic_load.py
+++ b/catch/utils/tests/test_dynamic_load.py
@@ -1,0 +1,48 @@
+"""Tests for dynamic_load module.
+"""
+
+import os
+import unittest
+
+from catch.utils import dynamic_load
+
+__author__ = 'Hayden Metsky <hayden@mit.edu>'
+
+
+class TestLoadModule(unittest.TestCase):
+    """Tests loading a module.
+    """
+
+    def setUp(self):
+        # Get the path to a test module relative to the path of this file
+        self.module_path = os.path.join(os.path.dirname(__file__),
+            'input/test_module.py')
+
+    def test_load_module(self):
+        # Load the module and check that it has the variable 'testvar'
+        # equal to 'testval'
+        module = dynamic_load.load_module_from_path(self.module_path)
+        self.assertEqual(module.testvar, 'testval')
+
+
+class TestLoadFunction(unittest.TestCase):
+    """Tests loading a function from a module.
+    """
+
+    def setUp(self):
+        # Get the path to a test module relative to the path of this file
+        self.module_path = os.path.join(os.path.dirname(__file__),
+            'input/test_module.py')
+
+    def test_no_such_function(self):
+        # Test loading a function that does not exist; should raise an
+        # exception
+        self.assertRaises(Exception, dynamic_load.load_function_from_path,
+                self.module_path, 'no_such_fn')
+
+    def test_load_function(self):
+        # Load the module and execute the function 'sum', checking its
+        # output
+        sum_fn = dynamic_load.load_function_from_path(self.module_path, 'sum')
+
+        self.assertEqual(sum_fn(1, 2), 3)


### PR DESCRIPTION
Previously, a user could define a function in CATCH that implements a custom model to determine whether a probe hybridizes to a region of target sequence (e.g., to incorporate a calculation of free energy). The user would then need to set the `cover_range_fn` parameter where necessary (e.g., in the `set_cover_filter` module) to use this custom function.

This pull request makes it easier to use a custom function that determines hybridization. It exposes this ability by adding the `--custom-hybridization-fn` argument to the main `design.py` executable. (Likewise, it adds an argument for a more tolerant function to use with blacklisting genomes and differential identification.) The argument provides a path to a Python function, and CATCH dynamically loads this and uses it whenever it calculates hybridization between a probe and target sequence.