### PR TITLE
Expose option to set `kmer_probe_map_k` parameter

### DIFF
--- a/bin/analyze_probe_coverage.py
+++ b/bin/analyze_probe_coverage.py
@@ -45,7 +45,8 @@ def main(args):
         genomes_grouped,
         genomes_grouped_names,
         island_of_exact_match=args.island_of_exact_match,
-        cover_extension=args.cover_extension)
+        cover_extension=args.cover_extension,
+        kmer_probe_map_k=args.kmer_probe_map_k)
     analyzer.run()
     if args.write_analysis_to_tsv:
         analyzer.write_data_matrix_as_tsv(
@@ -125,7 +126,7 @@ if __name__ == "__main__":
               "by the probe set within sliding windows of each target "
               "genome"))
 
-    # Number of processes to use
+    # Technical adjustments
     def check_max_num_processes(val):
         ival = int(val)
         if ival >= 1:
@@ -138,6 +139,24 @@ if __name__ == "__main__":
         help=("(Optional) An int >= 1 that gives the maximum number of "
               "processes to use in multiprocessing pools; uses min(number "
               "of CPUs in the system, MAX_NUM_PROCESSES) processes"))
+    parser.add_argument('--kmer-probe-map-k',
+        type=int,
+        default=10,
+        help=("(Optional) Use this value (KMER_PROBE_LENGTH_K) as the "
+              "k-mer length when constructing a map of k-mers to the probes "
+              "that contain these k-mers. This map is used when mapping "
+              "the given probes to target sequences and the k-mers serve "
+              "as seeds for calculating whether a probe 'covers' "
+              "a subsequence. The value should be sufficiently less than "
+              "the probe length (PROBE_LENGTH) so that it can find mappings "
+              "even when the candidate probe and target sequence are "
+              "divergent. In particular, CATCH will try to find a value k >= "
+              "KMER_PROBE_LENGTH_K (by default, >=10) such that k divides "
+              "PROBE_LENGTH and k < PROBE_LENGTH / MISMATCHES (if "
+              "MISMATCHES=0, then k=PROBE_LENGTH). It will then use this "
+              "k as the k-mer length in mappings; if no such k exists, it "
+              "will use a randomized approach with KMER_PROBE_LENGTH_K as "
+              "the k-mer length."))
 
     # Logging levels and version
     parser.add_argument('--debug',

--- a/catch/tests/test_probe.py
+++ b/catch/tests/test_probe.py
@@ -745,7 +745,7 @@ class TestFindProbeCoversInSequence(unittest.TestCase):
     def test_random_small_genome1(self):
         self.run_random(100, 15000, 25000, 300, seed=1)
 
-    def test_random_small_genome1(self):
+    def test_random_small_genome2(self):
         self.run_random(100, 15000, 25000, 300, probe_length=75,
                         lcf_thres=75, seed=2)
 

--- a/catch/tests/test_probe.py
+++ b/catch/tests/test_probe.py
@@ -749,6 +749,11 @@ class TestFindProbeCoversInSequence(unittest.TestCase):
         self.run_random(100, 15000, 25000, 300, probe_length=75,
                         lcf_thres=75, seed=2)
 
+    def test_random_small_genome_varied_k(self):
+        for k in [21, 15, 13, 10]:
+            self.run_random(100, 15000, 25000, 300,
+                kmer_probe_map_k=k, seed=1)
+
     def test_random_large_genome1(self):
         self.run_random(1, 1500000, 2500000, 30000,
                         lcf_thres=100, seed=1)
@@ -761,13 +766,18 @@ class TestFindProbeCoversInSequence(unittest.TestCase):
         self.run_random(1, 500000, 1000000, 6000, probe_length=75,
                         lcf_thres=75, seed=3)
 
+    def test_random_large_genome_varied_k(self):
+        for k in [21, 15, 13, 10]:
+            self.run_random(1, 1500000, 2500000, 30000,
+                            lcf_thres=100, kmer_probe_map_k=k, seed=1)
+
     def test_random_large_genome_native_dict(self):
         self.run_random(1, 1500000, 2500000, 30000,
                         lcf_thres=100, seed=4, use_native_dict=True)
 
     def run_random(self, n, genome_min, genome_max, num_probes,
-                   probe_length=100, lcf_thres=None, seed=1, n_workers=2,
-                   use_native_dict=False):
+                   probe_length=100, lcf_thres=None, kmer_probe_map_k=20,
+                   seed=1, n_workers=2, use_native_dict=False):
         """Run tests with a randomly generated sequence.
 
         Repeatedly runs tests in which a sequence is randomly generated,
@@ -786,6 +796,8 @@ class TestFindProbeCoversInSequence(unittest.TestCase):
             probe_length: number of bp to make each probe
             lcf_thres: lcf threshold parameter; when None, it is
                 randomly chosen among 80 and 100
+            kmer_probe_map_k: k-mer length to use when constructing the
+                map of k-mers to probes
             seed: random number generator seed
             n_workers: number of workers to have in a probe finding pool
             use_native_dict: have the probe finding pool use a native Python
@@ -839,7 +851,8 @@ class TestFindProbeCoversInSequence(unittest.TestCase):
                 desired_probe_cover_ranges[p].append((cover_start, cover_end))
                 probes += [p]
             kmer_map = probe.construct_kmer_probe_map_to_find_probe_covers(
-                probes, 3, lcf_thres)
+                probes, 3, lcf_thres,
+                min_k=kmer_probe_map_k, k=kmer_probe_map_k)
             kmer_map = probe.SharedKmerProbeMap.construct(kmer_map)
             f = probe.probe_covers_sequence_by_longest_common_substring(
                 3, lcf_thres)


### PR DESCRIPTION
This adds a `--kmer-probe-map-k` argument, which specifies the k-mer length used when constructing a map of k-mers to probes.  (In particular, CATCH tries to determine a suitable k-mer length using this value as a lower bound; if it cannot, it takes a randomized approach and uses this value as the k-mer length.)

This is useful when designing short probes (e.g., meant to be primers), in which case the default k-mer length may be too short relative to the probe to find mappings of the probes to the target sequence.