### PR TITLE
Speed up construction of universe from IntervalSets

### DIFF
--- a/catch/utils/tests/test_interval.py
+++ b/catch/utils/tests/test_interval.py
@@ -62,9 +62,15 @@ class TestIntervalSet(unittest.TestCase):
         a = IntervalSet(input_a)
         b = IntervalSet(input_b)
         o = IntervalSet(desired_output)
+
         # Union is commutative, so check both orders
         self.assertEqual(a.union(b), o)
         self.assertEqual(b.union(a), o)
+
+        # Making a new IntervalSet should merge overlapping
+        # intervals, effectively taking the union
+        ab = IntervalSet(input_a + input_b)
+        self.assertEqual(ab, o)
 
     def test_union(self):
         self.compare_union([], [], [])
@@ -77,6 +83,7 @@ class TestIntervalSet(unittest.TestCase):
         self.compare_union([(1, 10)], [(3, 7)], [(1, 10)])
         self.compare_union([(2, 100)], [(0, 50)], [(0, 100)])
         self.compare_union([(0, 7)], [(4, 10)], [(0, 10)])
+        self.compare_union([(4, 10)], [(0, 7)], [(0, 10)])
         self.compare_union([(1, 5), (10, 15)], [(1, 5), (15, 20)], [(1, 5),
                                                                     (10, 20)])
         self.compare_union([(1, 5), (10, 15)], [(3, 12)], [(1, 15)])


### PR DESCRIPTION
`set_cover.approx_multiuniverse()` constructs the universes by taking
the union over all input sets. When `use_intervalsets` is True,
this was previously slow. (`use_intervalsets` is True for most runs because
[`set_cover_filter` sets it to True](https://github.com/broadinstitute/catch/blob/745499f9e2c3d2c88fc6da45b0e10c6c58a6de22/catch/filter/set_cover_filter.py#L735).) It worked by creating an empty
IntervalSet, and then repeatedly taking the union of the universe's
IntervalSet with another input set (also represented as an IntervalSet).
In the worst-case, taking the union takes O(_n_) time where _n_ is the
current size of the universe. As a result, constructing the universe
took, in the worst-case, O(_n_^2) time. For particularly long genomes,
where _n_ is large, this could take hours in practice.

This fix instead initializes each universe by simply constructing
a list of the input intervals for it, and then initializing an IntervalSet
from the list. Initializing the IntervalSet already merges overlapping
intervals (effectively taking the union of all of them) in O(_N_ log _N_)
time, where _N_ is the number of input intervals. Since the input sets
are constructed from the universe, _N_ is O(_n_), where _n_ is defined above.
So, now, constructing the universe takes, in the worst-case, O(_n_ log _n_)
time. In practice, this seems to provide a noticeable speed up as well.