### PR TITLE
Allow skipping input sequences that are too short

### DIFF
--- a/bin/design.py
+++ b/bin/design.py
@@ -153,6 +153,12 @@ def main(args):
                 "--adapter-a and --adapter-b, but --add-adapters is required "
                 "to add adapter sequences onto the ends of probes"))
 
+    # Do not allow both --small-seq-skip and --small-seq-min, since they
+    # have different intentions
+    if args.small_seq_skip is not None and args.small_seq_min is not None:
+        raise Exception(("Both --small-seq-skip and --small-seq-min were "
+            "specified, but both cannot be used together"))
+
     # Check for whether a custom hybridization function was provided
     if args.custom_hybridization_fn:
         custom_cover_range_fn = tuple(args.custom_hybridization_fn)
@@ -293,7 +299,8 @@ def main(args):
     pb = probe_designer.ProbeDesigner(genomes_grouped, filters,
                                       probe_length=args.probe_length,
                                       probe_stride=args.probe_stride,
-                                      allow_small_seqs=args.small_seq_min)
+                                      allow_small_seqs=args.small_seq_min,
+                                      seq_length_to_skip=args.small_seq_skip)
     pb.design()
 
     # Write the final probes to the file args.output_probes
@@ -648,6 +655,12 @@ if __name__ == "__main__":
               "from each grouping and pool (union) the resulting probes. "
               "When set, the software will run faster than when not set, but "
               "it may yield more probes than when it is not set."))
+    parser.add_argument('--small-seq-skip',
+        type=int,
+        help=("(Optional) Do not create candidate probes from sequences "
+              "whose length is <= SMALL_SEQ_SKIP. If set to (PROBE_LENGTH - "
+              "1), this avoids the error raised when sequences are less "
+              "than the probe length"))
     parser.add_argument('--small-seq-min',
         type=int,
         help=("(Optional) If set, allow sequences as input that are "

--- a/catch/filter/candidate_probes.py
+++ b/catch/filter/candidate_probes.py
@@ -4,6 +4,7 @@ These functions compute lists of many (likely redundant) probes, termed
 candidate probes, from a sequence of list of sequences.
 """
 
+import logging
 import re
 import sys
 
@@ -13,6 +14,8 @@ from catch import probe
 from catch.utils import seq_io
 
 __author__ = 'Hayden Metsky <hayden@mit.edu>'
+
+logger = logging.getLogger(__name__)
 
 
 def make_candidate_probes_from_sequence(seq,
@@ -125,7 +128,8 @@ def make_candidate_probes_from_sequences(
         probe_length,
         probe_stride,
         min_n_string_length=2,
-        allow_small_seqs=None):
+        allow_small_seqs=None,
+        seq_length_to_skip=None):
     """Generate a list of candidate probes from a list of sequences.
 
     It is possible (perhaps even likely depending on where
@@ -143,6 +147,9 @@ def make_candidate_probes_from_sequences(
         allow_small_seqs: if set, allow sequences that are smaller than the
             probe length by creating candidate probes equal to the sequence;
             the value gives the minimum allowed probe (sequence) length
+        seq_length_to_skip: if set, skip sequences whose length is <=
+            the given value (i.e., do not design candidate probes for
+            them)
 
     Returns:
         list of candidate probes as instances of probe.Probe
@@ -157,6 +164,13 @@ def make_candidate_probes_from_sequences(
 
     probes = []
     for seq in seqs:
+        if seq_length_to_skip is not None:
+            if len(seq) <= seq_length_to_skip:
+                logger.info(("Not designing candidate probes for a "
+                    "sequence with length %d, since it is <= %d"),
+                    len(seq), seq_length_to_skip)
+                continue
+
         probes += make_candidate_probes_from_sequence(
             seq,
             probe_length=probe_length,

--- a/catch/filter/probe_designer.py
+++ b/catch/filter/probe_designer.py
@@ -17,7 +17,7 @@ class ProbeDesigner:
     """
 
     def __init__(self, genomes, filters, probe_length,
-            probe_stride, allow_small_seqs=None):
+            probe_stride, allow_small_seqs=None, seq_length_to_skip=None):
         """
         Args:
             genomes: list [g_1, g_2, g_m] of m groupings of genomes, where
@@ -32,12 +32,16 @@ class ProbeDesigner:
             allow_small_seqs: if set, allow sequences that are smaller than the
                 probe length by creating candidate probes equal to the sequence;
                 the value gives the minimum allowed probe (sequence) length
+            seq_length_to_skip: if set, skip sequences whose length is <=
+                the given value (i.e., do not design candidate probes for
+                them)
         """
         self.genomes = genomes
         self.filters = filters
         self.probe_length = probe_length
         self.probe_stride = probe_stride
         self.allow_small_seqs = allow_small_seqs
+        self.seq_length_to_skip = seq_length_to_skip
 
     def design(self):
         """Design probes using the provided filters.
@@ -55,7 +59,8 @@ class ProbeDesigner:
                     make_candidate_probes_from_sequences(
                         g.seqs, probe_length=self.probe_length,
                         probe_stride=self.probe_stride,
-                        allow_small_seqs=self.allow_small_seqs)
+                        allow_small_seqs=self.allow_small_seqs,
+                        seq_length_to_skip=self.seq_length_to_skip)
 
         probes = self.candidate_probes
         for f in self.filters:

--- a/catch/filter/tests/test_candidate_probes.py
+++ b/catch/filter/tests/test_candidate_probes.py
@@ -1,6 +1,7 @@
 """Tests for candidate_probes module.
 """
 
+import logging
 import unittest
 
 from catch.datasets import zaire_ebolavirus
@@ -13,6 +14,10 @@ __author__ = 'Hayden Metsky <hayden@mit.edu>'
 class TestCandidateProbesOnContrivedInput(unittest.TestCase):
     """Tests explicitly the generated candidate probes from contrived input.
     """
+
+    def setUp(self):
+        # Disable logging
+        logging.disable(logging.WARNING)
 
     def test_no_n(self):
         p = candidate_probes.make_candidate_probes_from_sequence(
@@ -97,6 +102,7 @@ class TestCandidateProbesOnContrivedInput(unittest.TestCase):
                 allow_small_seqs=4,
                 min_n_string_length=2)
 
+        # With allow_small_seqs
         p = candidate_probes.make_candidate_probes_from_sequences(
             ['ATCGATCGATCG', 'CCGG'],
             probe_length=6,
@@ -105,6 +111,20 @@ class TestCandidateProbesOnContrivedInput(unittest.TestCase):
             min_n_string_length=2)
         p = [''.join(x.seq) for x in p]
         self.assertCountEqual(p, ['ATCGAT', 'GATCGA', 'CGATCG'] + ['CCGG'])
+
+        # With seq_length_to_skip
+        p = candidate_probes.make_candidate_probes_from_sequences(
+            ['ATCGATCGATCG', 'CCGG'],
+            probe_length=6,
+            probe_stride=3,
+            seq_length_to_skip=4,
+            min_n_string_length=2)
+        p = [''.join(x.seq) for x in p]
+        self.assertCountEqual(p, ['ATCGAT', 'GATCGA', 'CGATCG'])
+
+    def tearDown(self):
+        # Re-enable logging
+        logging.disable(logging.NOTSET)
 
 
 class TestCandidateProbesOnEbolaZaire(unittest.TestCase):
@@ -117,6 +137,9 @@ class TestCandidateProbesOnEbolaZaire(unittest.TestCase):
         Only process the first 100 genomes to avoid using too much memory
         with the candidate probes.
         """
+        # Disable logging
+        logging.disable(logging.WARNING)
+
         seqs = [gnm.seqs[0]
                 for gnm in seq_io.read_dataset_genomes(zaire_ebolavirus)]
         seqs = seqs[:100]
@@ -156,3 +179,7 @@ class TestCandidateProbesOnEbolaZaire(unittest.TestCase):
             self.assertNotIn('NN', ''.join(probe.seq))
         for probe in self.probes_75:
             self.assertNotIn('NN', ''.join(probe.seq))
+
+    def tearDown(self):
+        # Re-enable logging
+        logging.disable(logging.NOTSET)

--- a/catch/tests/test_probe.py
+++ b/catch/tests/test_probe.py
@@ -699,6 +699,29 @@ class TestFindProbeCoversInSequence(unittest.TestCase):
             self.assertFalse(c in found)
             probe.close_probe_finding_pool()
 
+    def test_too_short_sequence(self):
+        """Tests with sequence shorter than the probe length.
+        """
+        np.random.seed(1)
+        sequence = 'ABCDEFGHI'
+        a = probe.Probe.from_str('ABCDEFGHIJKL')
+        b = probe.Probe.from_str('EFGHIJKLMNOP')
+        c = probe.Probe.from_str('DEFGHIJKLMNO')
+        d = probe.Probe.from_str('XYZXYZABCDEF')
+        probes = [a, b, c, d]
+        kmer_map = probe.construct_kmer_probe_map_to_find_probe_covers(
+            probes, 0, 6, min_k=6, k=6)
+        kmer_map = probe.SharedKmerProbeMap.construct(kmer_map)
+        f = probe.probe_covers_sequence_by_longest_common_substring(0, 6)
+        for n_workers in [1, 2, 4, 7, 8]:
+            probe.open_probe_finding_pool(kmer_map, f, n_workers)
+            found = probe.find_probe_covers_in_sequence(sequence)
+            self.assertCountEqual(found[a], [(0, 9)])
+            self.assertFalse(b in found)
+            self.assertCountEqual(found[c], [(3, 9)])
+            self.assertCountEqual(found[d], [(0, 6)])
+            probe.close_probe_finding_pool()
+
     def test_multiple_searches_with_same_pool(self):
         """Tests more than one call to find_probe_covers_in_sequence()
         with the same pool.


### PR DESCRIPTION
Sometimes a sequence in an input dataset is too short; in particular, if it is shorter than the probe length, the `candidate_probes` module is unable to design candidate probes from it and raises an error. One way to fix this is with the existing `--small-seq-min` argument, which allows designing short probes against those sequences.

This argument provides another way to handle this: it allows the `candidate_probes` module to skip over sequences that are shorter than a specified value (typically the probe length minus 1). Note that it is possible that such sequences will not be covered in the design (i.e., if no other candidate probe covers them).