### PR TITLE
Add options to cluster input sequences and design on each cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ If not set, CATCH uses its default model of hybridization based on `-m/--mismatc
 * `--filter-with-lsh-hamming FILTER_WITH_LSH_HAMMING`/`--filter-with-lsh-minhash FILTER_WITH_LSH_MINHASH`: Use locality-sensitive hashing to reduce the space of candidate probes.
 This can significantly improve runtime and memory requirements when the input is especially large and diverse.
 See `design.py --help` for details on using these options and downsides.
+* `--cluster-and-design-separately CLUSTER_AND_DESIGN_SEPARATELY`: Cluster input sequences prior to design by computing their MinHash signatures and comparing them.
+Then, design probes separately on each cluster and merge the resulting probes.
+Like the `--filter-with-{hamming,minhash}` arguments, this is another option to improve runtime and memory requirements on large and diverse input.
+CLUSTER_AND_DESIGN_SEPARATELY gives the inter-cluster distance threshold for merging clusters, expressed as average nucleotide dissimilarity (1-ANI).
+See `design.py --help` for details and, relatedly, see the `--cluster-from-fragments` argument.
 
 ### Pooling across many runs ([`pool.py`](./bin/pool.py))
 

--- a/bin/design.py
+++ b/bin/design.py
@@ -21,6 +21,7 @@ from catch.filter import polya_filter
 from catch.filter import probe_designer
 from catch.filter import reverse_complement_filter
 from catch.filter import set_cover_filter
+from catch.utils import cluster
 from catch.utils import seq_io, version, log
 
 __author__ = 'Hayden Metsky <hayden@mit.edu>'
@@ -139,6 +140,8 @@ def main(args):
     # Set the maximum number of processes in multiprocessing pools
     if args.max_num_processes:
         probe.set_max_num_processes_for_probe_finding_pools(
+            args.max_num_processes)
+        cluster.set_max_num_processes_for_creating_distance_matrix(
             args.max_num_processes)
 
     # Raise exceptions or warn based on use of adapter arguments

--- a/catch/filter/adapter_filter.py
+++ b/catch/filter/adapter_filter.py
@@ -294,14 +294,14 @@ class AdapterFilter(BaseFilter):
             votes_sum += [tuple(x + y for x, y in zip(vote_x, vote_y))]
         return votes_sum
 
-    def _make_votes_across_target_genomes(self, probes):
+    def _make_votes_across_target_genomes(self, probes, target_genomes):
         """Compute, for each probe, votes for adapters to the probe.
 
-        Votes are computed, cumulatively, across all the target genomes in
-        self.target_genomes.
+        Votes are computed, cumulatively, across all the target genomes.
 
         Args:
             probes: list of candidate probes
+            target_genomes: list of groupings of genomes
 
         Returns:
             a list L such that L[i] is a tuple (A,B) where A gives the
@@ -321,7 +321,7 @@ class AdapterFilter(BaseFilter):
                                       self.cover_range_fn)
 
         def iter_all_seqs():
-            for genomes_from_group in self.target_genomes:
+            for genomes_from_group in target_genomes:
                 for g in genomes_from_group:
                     for seq in g.seqs:
                         yield seq
@@ -361,14 +361,14 @@ class AdapterFilter(BaseFilter):
 
         return cumulative_votes
 
-    def _filter(self, input):
+    def _filter(self, input, target_genomes):
         """Add adapters to input probes.
         """
         # Ensure that the input is a list
         input = list(input)
 
         logger.info("Computing adapter votes across all target genomes")
-        votes = self._make_votes_across_target_genomes(input)
+        votes = self._make_votes_across_target_genomes(input, target_genomes)
 
         # Using votes, select the adapter for each probe (the one with
         # the most number of votes) and create a new probe that has

--- a/catch/filter/base_filter.py
+++ b/catch/filter/base_filter.py
@@ -1,6 +1,8 @@
 """Wrappers around a filter, meant to abstract away common tasks.
 """
 
+import inspect
+
 __author__ = 'Hayden Metsky <hayden@mit.edu>'
 
 
@@ -17,24 +19,30 @@ class BaseFilter:
     input probes.
 
     All subclasses must implement a _filter(..) method that returns a
-    list of probes after processing from the given input list. This
-    saves the input probes in self.input_probes and the output probes in
-    self.output_probes.
+    list of probes after processing from the given input list.
     """
 
-    def filter(self, input):
+    def filter(self, input, target_genomes=None):
         """Perform the filtering.
 
         Args:
             input: list of candidate probes
+            target_genomes: list [g_1, g_2, g_m] of m groupings of genomes,
+                where each g_i is a list of genome.Genomes belonging to group
+                i, that should be targeted by the probes; for example a
+                group may be a species and each g_i would be a list of the
+                target genomes of species i
 
         Returns:
             list of probes after applying a filter to the input
         """
-        self.input_probes = input
-        filtered = self._filter(input)
-        self.output_probes = filtered
-        return filtered
+        _filter_params = inspect.signature(self._filter).parameters
+        if len(_filter_params) == 2:
+            # _filter() should accept both probes and target genomes
+            return self._filter(input, target_genomes)
+        else:
+            # _filter() may not need target genomes, and does not accept it
+            return self._filter(input)
 
     def _filter(self, input):
         raise Exception(("A subclass of BaseFilter must implement "

--- a/catch/filter/candidate_probes.py
+++ b/catch/filter/candidate_probes.py
@@ -62,7 +62,8 @@ def make_candidate_probes_from_sequence(seq,
                     return [probe.Probe.from_str(seq)]
         else:
             raise ValueError(("An input sequence is smaller than the probe "
-                              "length (" + str(probe_length) + ")"))
+                              "length (" + str(probe_length) + "); try "
+                              "setting --small-seq-skip"))
 
     if isinstance(seq, np.ndarray):
         seq = ''.join(seq)

--- a/catch/filter/probe_designer.py
+++ b/catch/filter/probe_designer.py
@@ -91,12 +91,17 @@ class ProbeDesigner:
                 if self.cluster_fragment_length is not None:
                     # Break g into fragments
                     g_fragments = g.break_into_fragments(
-                            self.cluster_fragment_length)
+                            self.cluster_fragment_length,
+                            include_full_end=True)
                     g_seqs = g_fragments.seqs
                 else:
                     # Do not break into fragments; use whole sequences
                     g_seqs = g.seqs
                 for s in g_seqs:
+                    if (self.seq_length_to_skip is not None and
+                            len(s) <= self.seq_length_to_skip):
+                        # Skip this sequence, which is too short
+                        continue
                     seqs[seq_idx] = s
                     seq_idx += 1
 

--- a/catch/filter/probe_designer.py
+++ b/catch/filter/probe_designer.py
@@ -80,10 +80,14 @@ class ProbeDesigner:
                     seqs[seq_idx] = s
                     seq_idx += 1
 
-        logger.info(("Clustering %d sequences using MinHash signatures"),
-                seq_idx)
+        logger.info(("Clustering %d sequences using MinHash signatures, at an "
+            "average nucleotide dissimilarity threshold of %f"),
+                seq_idx, self.cluster_threshold)
         clusters = cluster.cluster_with_minhash_signatures(seqs,
                 threshold=self.cluster_threshold)
+
+        logger.info(("Found %d clusters with sizes: %s"), len(clusters),
+                [len(clust) for clust in clusters])
 
         clustered_genomes = []
         for clust in clusters:

--- a/catch/filter/probe_designer.py
+++ b/catch/filter/probe_designer.py
@@ -4,6 +4,8 @@
 import logging
 
 from catch.filter import candidate_probes
+from catch import genome
+from catch.utils import cluster
 
 __author__ = 'Hayden Metsky <hayden@mit.edu>'
 
@@ -17,7 +19,8 @@ class ProbeDesigner:
     """
 
     def __init__(self, genomes, filters, probe_length,
-            probe_stride, allow_small_seqs=None, seq_length_to_skip=None):
+            probe_stride, allow_small_seqs=None, seq_length_to_skip=None,
+            cluster_threshold=None, cluster_merge_after=None):
         """
         Args:
             genomes: list [g_1, g_2, g_m] of m groupings of genomes, where
@@ -35,6 +38,15 @@ class ProbeDesigner:
             seq_length_to_skip: if set, skip sequences whose length is <=
                 the given value (i.e., do not design candidate probes for
                 them)
+            cluster_threshold: if set, cluster genomes and run filters (except
+                the final ones) separately on each cluster, and merge probes;
+                this value is the inter-cluster distance to merge clusters,
+                in average nucleotide dissimilarity (1-ANI, where ANI is
+                average nucleotide identity); higher results in fewer clusters
+            cluster_merge_after: a filter in filters such that output probes
+                from each cluster are merged just after running this filter,
+                and all subsequent filters are run on the merged list; must be
+                set if cluster_threshold is set
         """
         self.genomes = genomes
         self.filters = filters
@@ -42,28 +54,121 @@ class ProbeDesigner:
         self.probe_stride = probe_stride
         self.allow_small_seqs = allow_small_seqs
         self.seq_length_to_skip = seq_length_to_skip
+        self.cluster_threshold = cluster_threshold
+        self.cluster_merge_after = cluster_merge_after
 
-    def design(self):
-        """Design probes using the provided filters.
+    def _cluster_genomes(self):
+        """Cluster genomes by nucleotide similarity using MinHash signatures.
 
-        Generates the set of candidate probes and runs these through the
-        filters. Stores the candidate probes in self.candidate_probes and
-        the probes processed by the filters in self.final_probes.
+        This collapses all sequences, across both groups and genomes, into one
+        list of sequences in one group. Therefore, genomes will not be grouped
+        as specified in the input and sequences will not be grouped by genome.
+
+        Returns:
+            list of Genome objects, where each consists of a single sequence
         """
-
-        logger.info("Building candidate probes from target sequences")
-        self.candidate_probes = []
+        if len(self.genomes) > 1:
+            logger.warning(("There are >1 groups of genomes in the input, but "
+                "clustering these will result in just one group; differential "
+                "identification or other tasks that rely on group separation "
+                "will no longer work"))
+        seqs = {}
+        seq_idx = 0
         for genomes_from_group in self.genomes:
             for g in genomes_from_group:
-                self.candidate_probes += candidate_probes.\
+                for s in g.seqs:
+                    seqs[seq_idx] = s
+                    seq_idx += 1
+
+        logger.info(("Clustering %d sequences using MinHash signatures"),
+                seq_idx)
+        clusters = cluster.cluster_with_minhash_signatures(seqs,
+                threshold=self.cluster_threshold)
+
+        clustered_genomes = []
+        for clust in clusters:
+            genomes_in_clust = []
+            for seq_idx in clust:
+                seq = seqs[seq_idx]
+                genomes_in_clust += [genome.Genome.from_one_seq(seq)]
+            clustered_genomes += [genomes_in_clust]
+        return clustered_genomes
+
+    def _design_for_genomes(self, genomes, filters):
+        """Design probes on a subset of genomes using a subset of filters.
+
+        Generates the set of candidate probes and runs these through the
+        filters.
+
+        Args:
+            genomes: list [g_1, g_2, g_m] of m groupings of genomes, where
+                each g_i is a list of genome.Genomes belonging to group i.
+                For example, a group may be a species and each g_i would be
+                a list of the target genomes of species i.
+            filters: an (ordered) list of filters, each of which should be
+                an instance of a subclass of BaseFilter
+
+        Returns:
+            tuple (candidate_probes, output_probes) where candidate_probes is a
+            list of candidate probes and output_probes is the list of candidate
+            probes after passing through the provided filters
+        """
+        logger.info("Building candidate probes from target sequences")
+        candidates = []
+        for genomes_from_group in genomes:
+            for g in genomes_from_group:
+                candidates += candidate_probes.\
                     make_candidate_probes_from_sequences(
                         g.seqs, probe_length=self.probe_length,
                         probe_stride=self.probe_stride,
                         allow_small_seqs=self.allow_small_seqs,
                         seq_length_to_skip=self.seq_length_to_skip)
 
-        probes = self.candidate_probes
-        for f in self.filters:
+        probes = candidates
+        for f in filters:
+            logger.info("Starting filter %s", f.__class__.__name__)
+            f.target_genomes = genomes
+            probes = f.filter(probes)
+        return (candidates, probes)
+
+    def design(self):
+        """Design probes using the provided filters.
+
+        If desired, this first clusters sequences and then designs separately
+        for each cluster. This stores the resulting probes in
+        self.final_probes and all the candidate probes in
+        self.candidate_probes.
+        """
+        if self.cluster_threshold is None:
+            candidates, probes = self._design_for_genomes(self.genomes,
+                    self.filters)
+            self.candidate_probes = candidates
+            self.final_probes = probes
+            return
+
+        # Find filters before and after merging
+        assert self.cluster_merge_after is not None
+        assert self.cluster_merge_after in self.filters
+        filter_merge_idx = self.filters.index(self.cluster_merge_after) + 1
+        filters_before_merge = self.filters[:filter_merge_idx]
+        filters_after_merge = self.filters[filter_merge_idx:]
+
+        # Cluster genomes and design probes on each cluster
+        clustered_genomes = self._cluster_genomes()
+        candidates = []
+        probes = set()
+        for genomes in clustered_genomes:
+            candidates_for_cluster, probes_for_cluster = \
+                    self._design_for_genomes([genomes], filters_before_merge)
+            candidates += candidates_for_cluster
+            probes |= set(probes_for_cluster)
+
+        self.candidate_probes = candidates
+
+        # Run the remaining filters (filters_after_merge) on all the probes
+        # after the merge
+        probes = list(probes)
+        for f in filters_after_merge:
             logger.info("Starting filter %s", f.__class__.__name__)
             f.target_genomes = self.genomes
             probes = f.filter(probes)

--- a/catch/filter/tests/test_adapter_filter.py
+++ b/catch/filter/tests/test_adapter_filter.py
@@ -34,9 +34,8 @@ class TestAdapterFilter(unittest.TestCase):
                              mismatches=mismatches,
                              lcf_thres=lcf_thres,
                              kmer_probe_map_k=3)
-        f.target_genomes = target_genomes
-        f.filter(input_probes)
-        return (f, f.output_probes)
+        output_probes = f.filter(input_probes, target_genomes)
+        return (f, output_probes)
 
     def assert_has_adapter(self, probe, adapter):
         """Assert that probe has a particular adapter.
@@ -168,7 +167,7 @@ class TestAdapterFilter(unittest.TestCase):
             self.assertCountEqual(output, desired_output)
 
             # Check votes too
-            votes = f._make_votes_across_target_genomes(input)
+            votes = f._make_votes_across_target_genomes(input, target_genomes)
             if allowed_mismatches == 0:
                 # Each middle probe should align to one genome
                 self.assertEqual(votes, [(2, 0), (0, 1), (0, 1), (2, 0)])
@@ -199,7 +198,7 @@ class TestAdapterFilter(unittest.TestCase):
         self.assertCountEqual(output, desired_output)
 
         # Check votes too
-        votes = f._make_votes_across_target_genomes(input)
+        votes = f._make_votes_across_target_genomes(input, target_genomes)
         self.assertEqual(votes, [(0, 1), (2, 0), (0, 2), (2, 0), (0, 2),
                                  (2, 0)])
 
@@ -220,7 +219,7 @@ class TestAdapterFilter(unittest.TestCase):
         self.assertCountEqual(output, desired_output)
 
         # Check votes too
-        votes = f._make_votes_across_target_genomes(input)
+        votes = f._make_votes_across_target_genomes(input, target_genomes)
         self.assertEqual(votes, [(3, 0), (1, 2)])
 
     def test_with_mismatches(self):

--- a/catch/filter/tests/test_dominating_set_filter.py
+++ b/catch/filter/tests/test_dominating_set_filter.py
@@ -26,9 +26,8 @@ class TestDominatingSetFilter(unittest.TestCase):
                                  for s in desired_output]
         f = dsf.DominatingSetFilter(
             nrf.redundant_shift_and_mismatch_count(shift, mismatches))
-        f.filter(input_probes)
-        self.assertCountEqual(f.input_probes, input_probes)
-        self.assertCountEqual(f.output_probes, desired_output_probes)
+        output_probes = f.filter(input_probes)
+        self.assertCountEqual(output_probes, desired_output_probes)
 
     def test_one_shift_one_mismatch(self):
         input = ['ATCGTCGCGG', 'TCGTAGCGGA', 'CGTAGCGGAT']

--- a/catch/filter/tests/test_duplicate_filter.py
+++ b/catch/filter/tests/test_duplicate_filter.py
@@ -22,8 +22,7 @@ class TestDuplicateFilter(unittest.TestCase):
         desired_output_probes = [probe.Probe.from_str(s)
                                  for s in desired_output]
         f = duplicate_filter.DuplicateFilter()
-        f.filter(input_probes)
-        self.assertCountEqual(f.input_probes, input_probes)
+        output_probes = f.filter(input_probes)
         # Order should be preserved, so use assertEqual rather than
         # assertCountEqual
-        self.assertEqual(f.output_probes, desired_output_probes)
+        self.assertEqual(output_probes, desired_output_probes)

--- a/catch/filter/tests/test_fasta_filter.py
+++ b/catch/filter/tests/test_fasta_filter.py
@@ -35,8 +35,8 @@ class TestFastaFilter(unittest.TestCase):
         input_probes = [p1, p2, p3, p4, p5]
 
         fasta_filter = ff.FastaFilter(fasta_file.name)
-        fasta_filter.filter(input_probes)
-        self.assertEqual(fasta_filter.output_probes, [p4, p2])
+        output_probes = fasta_filter.filter(input_probes)
+        self.assertEqual(output_probes, [p4, p2])
 
         fasta_file.close()
 
@@ -60,8 +60,8 @@ class TestFastaFilter(unittest.TestCase):
 
         fasta_filter = ff.FastaFilter(fasta_file.name,
                                       skip_reverse_complements=True)
-        fasta_filter.filter(input_probes)
-        self.assertEqual(fasta_filter.output_probes, [p4, p2])
+        output_probes = fasta_filter.filter(input_probes)
+        self.assertEqual(output_probes, [p4, p2])
 
         fasta_file.close()
 

--- a/catch/filter/tests/test_n_expansion_filter.py
+++ b/catch/filter/tests/test_n_expansion_filter.py
@@ -24,9 +24,8 @@ class TestNExpansionFilter(unittest.TestCase):
                                  for s in desired_output]
         f = n_expansion_filter.NExpansionFilter(
                 limit_n_expansion_randomly=limit_n_expansion_randomly)
-        f.filter(input_probes)
-        self.assertEqual(f.input_probes, input_probes)
-        self.assertEqual(f.output_probes, desired_output_probes)
+        output_probes = f.filter(input_probes)
+        self.assertEqual(output_probes, desired_output_probes)
 
     def test_no_N(self):
         input = ['ATCG', 'ACTG']

--- a/catch/filter/tests/test_naive_redundant_filter.py
+++ b/catch/filter/tests/test_naive_redundant_filter.py
@@ -27,9 +27,8 @@ class TestNaiveRedundantFilterShiftAndMismatchCount(unittest.TestCase):
                                  for s in desired_output]
         f = nrf.NaiveRedundantFilter(
             nrf.redundant_shift_and_mismatch_count(shift, mismatches))
-        f.filter(input_probes)
-        self.assertCountEqual(f.input_probes, input_probes)
-        self.assertCountEqual(f.output_probes, desired_output_probes)
+        output_probes = f.filter(input_probes)
+        self.assertCountEqual(output_probes, desired_output_probes)
 
     def test_no_shift_no_mismatch(self):
         # This should detect and remove duplicates

--- a/catch/filter/tests/test_near_duplicate_filter.py
+++ b/catch/filter/tests/test_near_duplicate_filter.py
@@ -24,9 +24,9 @@ class TestNearDuplicateFilterWithHammingDistance(unittest.TestCase):
 
         f = ndf.NearDuplicateFilterWithHammingDistance(2, 10)
         f.k = 3
-        f.filter(input_probes)
-        self.assertEqual(len(f.output_probes), 1)
-        self.assertIn(f.output_probes[0], input_probes)
+        output_probes = f.filter(input_probes)
+        self.assertEqual(len(output_probes), 1)
+        self.assertIn(output_probes[0], input_probes)
 
     def test_all_similar_with_exact_dup(self):
         input = ['ATCGTCGCGG', 'ATCGTCGCGG', 'ATCGTGGCGG', 'TTCGTCGCGG',
@@ -35,11 +35,11 @@ class TestNearDuplicateFilterWithHammingDistance(unittest.TestCase):
 
         f = ndf.NearDuplicateFilterWithHammingDistance(2, 10)
         f.k = 3
-        f.filter(input_probes)
-        self.assertEqual(len(f.output_probes), 1)
+        output_probes = f.filter(input_probes)
+        self.assertEqual(len(output_probes), 1)
         # The first probe in input_probes is the most common, so this
         # should be the one that is kept
-        self.assertEqual(f.output_probes[0], input_probes[0])
+        self.assertEqual(output_probes[0], input_probes[0])
 
     def test_all_similar_but_zero_dist_thres(self):
         input = ['ATCGTCGCGG', 'ATCGTGGCGG', 'TTCGTCGCGG', 'ATCGGCGCGG']
@@ -47,8 +47,8 @@ class TestNearDuplicateFilterWithHammingDistance(unittest.TestCase):
 
         f = ndf.NearDuplicateFilterWithHammingDistance(0, 10)
         f.k = 3
-        f.filter(input_probes)
-        self.assertCountEqual(f.output_probes, input_probes)
+        output_probes = f.filter(input_probes)
+        self.assertCountEqual(output_probes, input_probes)
 
     def test_all_similar_but_one_too_far(self):
         input = ['ATCGTCGCGG', 'ATCGTGGCGG', 'TTCGTCGCGG', 'ATCGGCGCCT']
@@ -56,11 +56,11 @@ class TestNearDuplicateFilterWithHammingDistance(unittest.TestCase):
 
         f = ndf.NearDuplicateFilterWithHammingDistance(2, 10)
         f.k = 3
-        f.filter(input_probes)
-        self.assertEqual(len(f.output_probes), 2)
+        output_probes = f.filter(input_probes)
+        self.assertEqual(len(output_probes), 2)
         # The last probe in input_probes is barely >2 mismatches
         # from the others
-        self.assertIn(input_probes[-1], f.output_probes)
+        self.assertIn(input_probes[-1], output_probes)
 
     def test_two_clusters(self):
         cluster1 = ['ATCGTCGCGG', 'ATCGTGGCGG', 'TTCGTCGCGG', 'ATCGGCGCGG']
@@ -71,12 +71,12 @@ class TestNearDuplicateFilterWithHammingDistance(unittest.TestCase):
 
         f = ndf.NearDuplicateFilterWithHammingDistance(2, 10)
         f.k = 3
-        f.filter(input_probes)
-        self.assertEqual(len(f.output_probes), 2)
-        self.assertTrue((f.output_probes[0].seq_str in cluster1 and
-                         f.output_probes[1].seq_str in cluster2) or
-                        (f.output_probes[0].seq_str in cluster2 and
-                         f.output_probes[1].seq_str in cluster1))
+        output_probes = f.filter(input_probes)
+        self.assertEqual(len(output_probes), 2)
+        self.assertTrue((output_probes[0].seq_str in cluster1 and
+                         output_probes[1].seq_str in cluster2) or
+                        (output_probes[0].seq_str in cluster2 and
+                         output_probes[1].seq_str in cluster1))
 
 
 class TestNearDuplicateFilterWithMinHash(unittest.TestCase):
@@ -93,9 +93,9 @@ class TestNearDuplicateFilterWithMinHash(unittest.TestCase):
 
         f = ndf.NearDuplicateFilterWithMinHash(0.8, 3)
         f.k = 3
-        f.filter(input_probes)
-        self.assertEqual(len(f.output_probes), 1)
-        self.assertIn(f.output_probes[0], input_probes)
+        output_probes = f.filter(input_probes)
+        self.assertEqual(len(output_probes), 1)
+        self.assertIn(output_probes[0], input_probes)
 
     def test_all_similar_with_exact_dup(self):
         input = ['ATCGTCGCGG', 'ATCGTCGCGG', 'ATCGTGGCGG', 'TTCGTCGCGG',
@@ -104,11 +104,11 @@ class TestNearDuplicateFilterWithMinHash(unittest.TestCase):
 
         f = ndf.NearDuplicateFilterWithMinHash(0.8, 3)
         f.k = 3
-        f.filter(input_probes)
-        self.assertEqual(len(f.output_probes), 1)
+        output_probes = f.filter(input_probes)
+        self.assertEqual(len(output_probes), 1)
         # The first probe in input_probes is the most common, so this
         # should be the one that is kept
-        self.assertEqual(f.output_probes[0], input_probes[0])
+        self.assertEqual(output_probes[0], input_probes[0])
 
     def test_all_similar_but_zero_dist_thres(self):
         input = ['ATCGTCGCGG', 'ATCGTGGCGG', 'TTCGTCGCGG', 'ATCGGCGCGG']
@@ -116,8 +116,8 @@ class TestNearDuplicateFilterWithMinHash(unittest.TestCase):
 
         f = ndf.NearDuplicateFilterWithMinHash(0, 3)
         f.k = 3
-        f.filter(input_probes)
-        self.assertCountEqual(f.output_probes, input_probes)
+        output_probes = f.filter(input_probes)
+        self.assertCountEqual(output_probes, input_probes)
 
     def test_all_similar_but_one_too_far(self):
         input = ['ATCGTCGCGG', 'ATCGTGGCGG', 'TTCGTCGCGG', 'ATTGGGGCCA']
@@ -125,10 +125,10 @@ class TestNearDuplicateFilterWithMinHash(unittest.TestCase):
 
         f = ndf.NearDuplicateFilterWithMinHash(0.8, 3)
         f.k = 3
-        f.filter(input_probes)
-        self.assertEqual(len(f.output_probes), 2)
+        output_probes = f.filter(input_probes)
+        self.assertEqual(len(output_probes), 2)
         # The last probe in input_probes is far from the others
-        self.assertIn(input_probes[-1], f.output_probes)
+        self.assertIn(input_probes[-1], output_probes)
 
     def test_two_clusters(self):
         cluster1 = ['ATCGTCGCGG', 'ATCGTGGCGG', 'TTCGTCGCGG', 'ATCGGCGCGG']
@@ -139,9 +139,9 @@ class TestNearDuplicateFilterWithMinHash(unittest.TestCase):
 
         f = ndf.NearDuplicateFilterWithMinHash(0.8, 3)
         f.k = 3
-        f.filter(input_probes)
-        self.assertEqual(len(f.output_probes), 2)
-        self.assertTrue((f.output_probes[0].seq_str in cluster1 and
-                         f.output_probes[1].seq_str in cluster2) or
-                        (f.output_probes[0].seq_str in cluster2 and
-                         f.output_probes[1].seq_str in cluster1))
+        output_probes = f.filter(input_probes)
+        self.assertEqual(len(output_probes), 2)
+        self.assertTrue((output_probes[0].seq_str in cluster1 and
+                         output_probes[1].seq_str in cluster2) or
+                        (output_probes[0].seq_str in cluster2 and
+                         output_probes[1].seq_str in cluster1))

--- a/catch/filter/tests/test_polya_filter.py
+++ b/catch/filter/tests/test_polya_filter.py
@@ -20,9 +20,8 @@ class TestPolyAFilter(unittest.TestCase):
                                  for s in desired_output]
         f = polya_filter.PolyAFilter(length, mismatches,
             min_exact_length_to_consider=2)
-        f.filter(input_probes)
-        self.assertEqual(f.input_probes, input_probes)
-        self.assertEqual(f.output_probes, desired_output_probes)
+        output_probes = f.filter(input_probes)
+        self.assertEqual(output_probes, desired_output_probes)
 
     def test_no_polya(self):
         input = ['CCGGAAGGCC', 'GCGCGCGCGC']

--- a/catch/filter/tests/test_probe_designer.py
+++ b/catch/filter/tests/test_probe_designer.py
@@ -18,7 +18,7 @@ class TestProbeDesigner(unittest.TestCase):
 
     def setUp(self):
         # Disable logging
-        logging.disable(logging.INFO)
+        logging.disable(logging.WARNING)
 
     def test_one_filter1(self):
         """A basic test with a duplicate filter and one input sequence.
@@ -119,6 +119,74 @@ class TestProbeDesigner(unittest.TestCase):
         pb.design()
         self.assertEqual(pb.candidate_probes, desired_candidate_probes)
         self.assertEqual(pb.final_probes, desired_final_probes)
+
+    def tearDown(self):
+        # Re-enable logging
+        logging.disable(logging.NOTSET)
+
+
+class TestProbeDesignerWithClustering(unittest.TestCase):
+    """Tests the probe designer output, including cluster sequences, on
+    contrived input.
+    """
+
+    def setUp(self):
+        # Disable logging
+        logging.disable(logging.WARNING)
+
+    def test_cluster_genomes(self):
+        """Test the _cluster_genomes() function.
+        """
+        g1 = genome.Genome.from_one_seq('ATTA'*500)
+        g2 = genome.Genome.from_one_seq('TAAT'*500)
+        g3 = genome.Genome.from_one_seq('GC'*500)
+        g4 = genome.Genome.from_one_seq('CG'*500)
+        seqs = [[g1, g3], [g2, g4]]
+        pb = probe_designer.ProbeDesigner(seqs, [], probe_length=100,
+            probe_stride=50, cluster_threshold=0.1, cluster_merge_after=None)
+        clustered_genomes = pb._cluster_genomes()
+
+        # g1 and g2 should be in a cluster, and g3 and g4 should be in a
+        # cluster
+        self.assertEqual(len(clustered_genomes), 2)
+        cluster1 = clustered_genomes[0]
+        cluster2 = clustered_genomes[1]
+        if g1 in cluster1:
+            self.assertEqual(set(cluster1), set([g1, g2]))
+            self.assertEqual(set(cluster2), set([g3, g4]))
+        else:
+            self.assertEqual(set(cluster1), set([g3, g4]))
+            self.assertEqual(set(cluster2), set([g1, g2]))
+
+    def test_filter_with_clusters(self):
+        """Tests running two back-to-back DuplicateFilters, with the first
+        run on each cluster and the second run on the merge of the output
+        probes from the clusters.
+        """
+        g1 = genome.Genome.from_one_seq('ATTA'*500)
+        g2 = genome.Genome.from_one_seq('TAAT'*500)
+        g3 = genome.Genome.from_one_seq('GC'*500)
+        g4 = genome.Genome.from_one_seq('CG'*500)
+        seqs = [[g1, g3], [g2, g4]]
+
+        df1 = duplicate_filter.DuplicateFilter()
+        df2 = duplicate_filter.DuplicateFilter()
+        pb = probe_designer.ProbeDesigner(seqs, [df1, df2], probe_length=100,
+            probe_stride=8, cluster_threshold=0.1, cluster_merge_after=df1)
+        pb.design()
+
+        desired_candidate_probes = ['ATTA'*25, 'TAAT'*25, 'CG'*50, 'GC'*50]
+        desired_candidate_probes = \
+            [probe.Probe.from_str(s) for s in desired_candidate_probes]
+        desired_final_probes = ['A' * 75, 'A' * 50 + 'B' * 25,
+                                'A' * 25 + 'B' * 50, 'B' * 75,
+                                'B' * 50 + 'A' * 25, 'B' * 25 + 'A' * 50]
+        desired_final_probes = ['ATTA'*25, 'TAAT'*25, 'CG'*50, 'GC'*50]
+        desired_final_probes = \
+            [probe.Probe.from_str(s) for s in desired_final_probes]
+
+        self.assertEqual(set(pb.candidate_probes), set(desired_candidate_probes))
+        self.assertCountEqual(pb.final_probes, desired_final_probes)
 
     def tearDown(self):
         # Re-enable logging

--- a/catch/filter/tests/test_reverse_complement_filter.py
+++ b/catch/filter/tests/test_reverse_complement_filter.py
@@ -22,6 +22,5 @@ class TestReverseComplementFilter(unittest.TestCase):
         desired_output_probes = [probe.Probe.from_str(s)
                                  for s in desired_output]
         f = reverse_complement_filter.ReverseComplementFilter()
-        f.filter(input_probes)
-        self.assertCountEqual(f.input_probes, input_probes)
-        self.assertCountEqual(f.output_probes, desired_output_probes)
+        output_probes = f.filter(input_probes)
+        self.assertCountEqual(output_probes, desired_output_probes)

--- a/catch/filter/tests/test_set_cover_filter.py
+++ b/catch/filter/tests/test_set_cover_filter.py
@@ -45,9 +45,8 @@ class TestSetCoverFilter(unittest.TestCase):
             blacklisted_genomes=blacklisted_genomes,
             cover_groupings_separately=cover_groupings_separately,
             kmer_probe_map_k=3)
-        f.target_genomes = target_genomes
-        f.filter(input_probes)
-        return (f, f.output_probes)
+        output_probes = f.filter(input_probes, target_genomes)
+        return (f, output_probes)
 
     def verify_target_genome_coverage(self, selected_probes, target_genomes,
                                       filter, desired_coverage,
@@ -562,9 +561,8 @@ class TestSetCoverFilter(unittest.TestCase):
                                coverage=3,
                                custom_cover_range_fn=custom_cover_range_fn,
                                kmer_probe_map_k=3)
-        f.target_genomes = target_genomes
-        f.filter(candidate_probes)
-        self.assertEqual(set(f.output_probes), {probe.Probe.from_str('AAABCB')})
+        output_probes = f.filter(candidate_probes, target_genomes)
+        self.assertEqual(set(output_probes), {probe.Probe.from_str('AAABCB')})
 
     def tearDown(self):
         # Re-enable logging

--- a/catch/genome.py
+++ b/catch/genome.py
@@ -61,11 +61,16 @@ class Genome:
                 self.size_cached = sum(len(seq) for seq in self.seqs)
             return self.size_cached
 
-    def break_into_fragments(self, fragment_length):
+    def break_into_fragments(self, fragment_length, include_full_end=False):
         """Construct a new Genome with these sequences broken into fragments.
 
         Args:
             fragment_length: length of the fragment
+            include_full_end: if the last fragment is shorter than
+                fragment_length (because the length of a sequence is not a
+                multiple of fragment_length), instead use a fragment from
+                the end of the sequence with length fragment_length (the
+                last fragment_length nt)
 
         Returns:
             Genome object, containing multiple sequences that represent the
@@ -74,7 +79,13 @@ class Genome:
         """
         def fragments(seq):
             for i in range(0, len(seq), fragment_length):
-                yield seq[i:(i + fragment_length)]
+                fragment = seq[i:(i + fragment_length)]
+                if include_full_end and len(fragment) < fragment_length:
+                    # This is at the end of seq; instead, use the last
+                    # fragment_length nt
+                    yield seq[(len(seq) - fragment_length):]
+                else:
+                    yield fragment
 
         fragment_chrs = OrderedDict()
         if self.chrs is None:

--- a/catch/genome.py
+++ b/catch/genome.py
@@ -1,6 +1,8 @@
 """Structure(s) for storing and directly working with genomes.
 """
 
+from collections import OrderedDict
+
 __author__ = 'Hayden Metsky <hayden@mit.edu>'
 
 
@@ -58,6 +60,33 @@ class Genome:
             if self.size_cached is None:
                 self.size_cached = sum(len(seq) for seq in self.seqs)
             return self.size_cached
+
+    def break_into_fragments(self, fragment_length):
+        """Construct a new Genome with these sequences broken into fragments.
+
+        Args:
+            fragment_length: length of the fragment
+
+        Returns:
+            Genome object, containing multiple sequences that represent the
+            sequences in self.seqs broken into fragments of length
+            fragment_length
+        """
+        def fragments(seq):
+            for i in range(0, len(seq), fragment_length):
+                yield seq[i:(i + fragment_length)]
+
+        fragment_chrs = OrderedDict()
+        if self.chrs is None:
+            assert len(self.seqs) == 1
+            for fragment_idx, fragment in enumerate(fragments(self.seqs[0])):
+                fragment_chrs[str(fragment_idx)] = fragment
+        else:
+            for chr_name, chr_seq in self.chrs.items():
+                for fragment_idx, fragment in enumerate(fragments(chr_seq)):
+                    fragment_name = chr_name + '-' + str(fragment_idx)
+                    fragment_chrs[fragment_name] = fragment
+        return Genome.from_chrs(fragment_chrs)
 
     def __hash__(self):
         if self.hash_cached is None:

--- a/catch/tests/test_genome.py
+++ b/catch/tests/test_genome.py
@@ -77,3 +77,19 @@ class TestGenome(unittest.TestCase):
         self.assertNotEqual(genome_one_seq2, genome_two_chrs2)
         self.assertEqual(genome_two_chrs1, genome_two_chrs1)
         self.assertNotEqual(genome_two_chrs1, genome_two_chrs2)
+
+    def test_break_into_fragments_from_one_seq(self):
+        genome_one = genome.Genome.from_one_seq('ATCGTTAA')
+        broken = genome_one.break_into_fragments(3)
+        expected_genome = genome.Genome.from_chrs(
+                OrderedDict([('0', 'ATC'), ('1', 'GTT'), ('2', 'AA')]))
+        self.assertEqual(broken, expected_genome)
+
+    def test_break_into_fragments_from_chrs(self):
+        genome_two_chrs = genome.Genome.from_chrs(
+                OrderedDict([("chr1", 'ATCGTTAA'), ("chr2", 'AATTCCGGG')]))
+        broken = genome_two_chrs.break_into_fragments(3)
+        expected_genome = genome.Genome.from_chrs(
+                OrderedDict([("chr1-0", 'ATC'), ("chr1-1", 'GTT'), ("chr1-2", 'AA'),
+                             ("chr2-0", 'AAT'), ("chr2-1", 'TCC'), ("chr2-2", 'GGG')]))
+        self.assertEqual(broken, expected_genome)

--- a/catch/tests/test_genome.py
+++ b/catch/tests/test_genome.py
@@ -85,6 +85,13 @@ class TestGenome(unittest.TestCase):
                 OrderedDict([('0', 'ATC'), ('1', 'GTT'), ('2', 'AA')]))
         self.assertEqual(broken, expected_genome)
 
+    def test_break_into_fragments_from_one_seq_with_full_end(self):
+        genome_one = genome.Genome.from_one_seq('ATCGTTAA')
+        broken = genome_one.break_into_fragments(3, include_full_end=True)
+        expected_genome = genome.Genome.from_chrs(
+                OrderedDict([('0', 'ATC'), ('1', 'GTT'), ('2', 'TAA')]))
+        self.assertEqual(broken, expected_genome)
+
     def test_break_into_fragments_from_chrs(self):
         genome_two_chrs = genome.Genome.from_chrs(
                 OrderedDict([("chr1", 'ATCGTTAA'), ("chr2", 'AATTCCGGG')]))

--- a/catch/utils/cluster.py
+++ b/catch/utils/cluster.py
@@ -52,8 +52,15 @@ def create_condensed_dist_matrix(n, dist_fn):
     dist_matrix_len = int(n*(n-1)/2)
     dist_matrix = np.zeros(dist_matrix_len)
 
+    num_pairs = n*(n-1) / 2
+    pair_counter = 0
+    logger.debug(("Condensed distance matrix has %d entries"), num_pairs)
     for j in range(n):
         for i in range(j):
+            if (pair_counter + 1) % 100000 == 0:
+                logger.debug(("Computing condensed distance matrix entry "
+                    "%d of %d"), pair_counter + 1, num_pairs)
+            pair_counter += 1
             dist_matrix[idx(i, j)] = dist_fn(i, j)
 
     return dist_matrix

--- a/catch/utils/cluster.py
+++ b/catch/utils/cluster.py
@@ -1,0 +1,155 @@
+"""Functions for clustering sequences before input.
+
+This includes computing a distance matrix using MinHash, and
+clustering that matrix.
+"""
+
+from collections import defaultdict
+import logging
+import operator
+
+import numpy as np
+from scipy.cluster import hierarchy
+
+from catch.utils import lsh
+
+__author__ = 'Hayden Metsky <hayden@mit.edu>'
+
+logger = logging.getLogger(__name__)
+
+
+def make_signatures_with_minhash(family, seqs):
+    """Construct a signature using MinHash for each sequence.
+    Args:
+        family: lsh.MinHashFamily object
+        seqs: dict mapping sequence header to sequences
+    Returns:
+        dict mapping sequence header to signature
+    """
+    # Construct a single hash function; use the same for all sequences
+    h = family.make_h()
+
+    signatures = {}
+    for name, seq in seqs.items():
+        signatures[name] = h(seq)
+    return signatures
+
+
+def create_condensed_dist_matrix(n, dist_fn):
+    """Construct a 1d condensed distance matrix for scipy.
+    Args:
+        n: number of elements whose pairwise distances to store in the
+            matrix
+        dist_fn: function such that dist_fn(i, j) gives the distance
+            between i and j, for all i<j<n
+    Returns:
+        condensed 1d distance matrix for input to scipy functions
+    """
+    def idx(i, j):
+        # Compute index in 1d vector for pair (i, j)
+        return int((-1 * i*i)/2 + i*n - 3*i/2 + j - 1)
+
+    dist_matrix_len = int(n*(n-1)/2)
+    dist_matrix = np.zeros(dist_matrix_len)
+
+    for j in range(n):
+        for i in range(j):
+            dist_matrix[idx(i, j)] = dist_fn(i, j)
+
+    return dist_matrix
+
+
+def cluster_from_dist_matrix(dist_matrix, threshold):
+    """Use scipy to cluster a distance matrix.
+    Args:
+        dist_matrix: distance matrix, represented in scipy's 1d condensed form
+        threshold: maximum inter-cluster distance to merge clusters (higher
+            results in fewer clusters)
+    Returns:
+        list c such that c[i] is a collection of all the observations
+        (whose pairwise distances are indexed in dist) in the i'th
+        cluster, in sorted order by descending cluster size
+    """
+    linkage = hierarchy.linkage(dist_matrix, method='average')
+    clusters = hierarchy.fcluster(linkage, threshold, criterion='distance')
+
+    # clusters are numbered starting at 1, but base the count on
+    # first_clust_num just in case this changes
+    first_clust_num = min(clusters)
+    num_clusters = max(clusters) + 1 - first_clust_num
+    elements_in_cluster = defaultdict(list)
+    for i, clust_num in enumerate(clusters):
+        elements_in_cluster[clust_num].append(i)
+    cluster_sizes = {c: len(elements_in_cluster[c])
+                     for c in range(first_clust_num,
+                                    num_clusters + first_clust_num)}
+
+    elements_in_cluster_sorted = []
+    for clust_num, _ in sorted(cluster_sizes.items(),
+            key=operator.itemgetter(1), reverse=True):
+        elements_in_cluster_sorted += [elements_in_cluster[clust_num]]
+    return elements_in_cluster_sorted
+
+
+def cluster_with_minhash_signatures(seqs, k=12, N=100, threshold=0.1):
+    """Cluster sequences based on their MinHash signatures.
+    Args:
+        seqs: dict mapping sequence header to sequences
+        k: k-mer size to use for k-mer hashes (smaller is likely more
+            sensitive for divergent genomes, but may lead to false positives
+            in determining which genomes are close)
+        N: number of hash values to use in a signature (higher is slower for
+            clustering, but likely more sensitive for divergent genomes)
+        threshold: maximum inter-cluster distance to merge clusters, in
+            average nucleotide dissimilarity (1-ANI, where ANI is
+            average nucleotide identity); higher results in fewer
+            clusters
+    Returns:
+        list c such that c[i] gives a collection of sequence headers
+        in the same cluster, and the clusters in c are sorted
+        in descending order of size
+    """
+    num_seqs = len(seqs)
+
+    logger.info(("Producing signatures of %d sequences"), num_seqs)
+    family = lsh.MinHashFamily(k, N=N)
+    signatures_map = make_signatures_with_minhash(family, seqs)
+
+    # Map each sequence header to an index (0-based), and get
+    # the signature for the corresponding index
+    seq_headers = []
+    signatures = []
+    for name, seq in seqs.items():
+        seq_headers += [name]
+        signatures += [signatures_map[name]]
+
+    # Eq. 4 of the Mash paper (Ondov et al. 2016) shows that the
+    # Mash distance, which is shown to be closely related to 1-ANI, is:
+    #  D = (-1/k) * ln(2*j/(1+j))
+    # where j is a Jaccard similarity. Solving for j:
+    #  j = 1/(2*exp(k*D) - 1)
+    # So, for a desired distance D in terms of 1-ANI, the corresponding
+    # Jaccard distance is:
+    #  1.0 - 1/(2*exp(k*D) - 1)
+    # We can use this to calculate a clustering threshold in terms of
+    # Jaccard distance
+    jaccard_dist_threshold = 1.0 - 1.0/(2.0*np.exp(k*threshold) - 1)
+
+    def jaccard_dist(i, j):
+        # Return estimated Jaccard dist between signatures at
+        # index i and index j
+        return family.estimate_jaccard_dist(
+            signatures[i], signatures[j])
+
+    logger.info(("Creating condensed distance matrix of %d sequences"), num_seqs)
+    dist_matrix = create_condensed_dist_matrix(num_seqs, jaccard_dist)
+    logger.info(("Clustering %d sequences at Jaccard distance threshold of %f"),
+            num_seqs, jaccard_dist_threshold)
+    clusters = cluster_from_dist_matrix(dist_matrix,
+        jaccard_dist_threshold)
+
+    seqs_in_cluster = []
+    for cluster_idxs in clusters:
+        seqs_in_cluster += [[seq_headers[i] for i in cluster_idxs]]
+    return seqs_in_cluster
+

--- a/catch/utils/lsh.py
+++ b/catch/utils/lsh.py
@@ -110,7 +110,8 @@ class MinHashFamily:
             if num_kmers < self.N:
                 raise ValueError(("The number of k-mers (%d) in the given "
                     "sequence is too small to produce a signature of "
-                    "size %d") % (num_kmers, self.N))
+                    "size %d; try setting --small-seq-skip") %
+                    (num_kmers, self.N))
             def kmer_hashes():
                 for i in range(num_kmers):
                     kmer = s[i:(i + self.kmer_size)]

--- a/catch/utils/tests/test_cluster.py
+++ b/catch/utils/tests/test_cluster.py
@@ -1,0 +1,108 @@
+"""Tests for cluster module.
+"""
+
+import logging
+import unittest
+
+import numpy as np
+import scipy
+
+from catch.utils import cluster
+
+__author__ = 'Hayden Metsky <hayden@mit.edu>'
+
+
+class TestClusterFromMatrix(unittest.TestCase):
+    """Test basic clustering functions."""
+
+    def setUp(self):
+        # Disable logging
+        logging.disable(logging.WARNING)
+
+    def test_create_condensed_dist_matrix(self):
+        # Have 3 elements: 0 and 1 are similar, 0 and 2 are
+        # very dissimilar, and 1 and 2 are similar
+        n = 3
+        dist_matrix_2d = np.array(
+            [[0,   1, 100],
+             [1,   0, 2  ],
+             [100, 2, 0  ]])
+        def dist_fn(i, j):
+            return dist_matrix_2d[i][j]
+
+        condensed = cluster.create_condensed_dist_matrix(n, dist_fn)
+
+        # Use scipy to create a condensed matrix, which is possible
+        # since we already have the 2d matrix available
+        scipy_condensed = scipy.spatial.distance.squareform(dist_matrix_2d)
+
+        self.assertTrue(np.array_equal(condensed, scipy_condensed))
+
+    def test_cluster_from_dist_matrix_1(self):
+        # Have 3 elements: 0 and 1 are similar, 0 and 2 are
+        # very dissimilar, and 1 and 2 are similar
+        n = 3
+        dists = {(0, 1): 1, (0, 2): 100, (1, 2): 2}
+        def dist_fn(i, j):
+            return dists[(i, j)]
+        dist_matrix = cluster.create_condensed_dist_matrix(n, dist_fn)
+
+        clusters = cluster.cluster_from_dist_matrix(dist_matrix, 10)
+        self.assertEqual(clusters, [[0, 1], [2]])
+
+    def test_cluster_from_dist_matrix_2(self):
+        # Have 3 elements: 0 and 1 are very dissimilar similar, 0 and 2 are
+        # very dissimilar, and 1 and 2 are similar
+        n = 3
+        dists = {(0, 1): 100, (0, 2): 100, (1, 2): 1}
+        def dist_fn(i, j):
+            return dists[(i, j)]
+        dist_matrix = cluster.create_condensed_dist_matrix(n, dist_fn)
+
+        clusters = cluster.cluster_from_dist_matrix(dist_matrix, 10)
+        self.assertEqual(clusters, [[1, 2], [0]])
+
+    def test_cluster_from_dist_matrix_3(self):
+        # Have 3 elements: 0 and 1 are very dissimilar similar, 0 and 2 are
+        # very dissimilar, and 1 and 2 are similar
+        # Have 3 elements: all very dissimilar
+        n = 3
+        dists = {(0, 1): 20, (0, 2): 30, (1, 2): 40}
+        def dist_fn(i, j):
+            return dists[(i, j)]
+        dist_matrix = cluster.create_condensed_dist_matrix(n, dist_fn)
+
+        clusters = cluster.cluster_from_dist_matrix(dist_matrix, 10)
+        self.assertEqual(sorted(clusters), [[0], [1], [2]])
+
+    def tearDown(self):
+        # Re-enable logging
+        logging.disable(logging.NOTSET)
+
+
+class TestClusterWithMinHashSignatures(unittest.TestCase):
+    """Test cluster_with_minhash_signatures() function."""
+
+    def setUp(self):
+        # Disable logging
+        logging.disable(logging.WARNING)
+
+    def test_simple(self):
+        seqs = {'a': 'AT'*500,
+                'b': 'CG'*500,
+                'c': 'AT'*500,
+                'd': 'TA'*500,
+                'e': 'TT'*500,
+                'f': 'CG'*500}
+        # The expected clusters should be: [a, c, d], [b, f], [e]
+
+        clusters = cluster.cluster_with_minhash_signatures(seqs)
+        self.assertEqual(len(clusters), 3)
+        self.assertEqual(sorted(clusters[0]), ['a', 'c', 'd'])
+        self.assertEqual(sorted(clusters[1]), ['b', 'f'])
+        self.assertEqual(sorted(clusters[2]), ['e'])
+
+    def tearDown(self):
+        # Re-enable logging
+        logging.disable(logging.NOTSET)
+

--- a/catch/utils/tests/test_cluster.py
+++ b/catch/utils/tests/test_cluster.py
@@ -19,6 +19,19 @@ class TestClusterFromMatrix(unittest.TestCase):
         # Disable logging
         logging.disable(logging.WARNING)
 
+    def create_condensed_dist_matrix(self, n, dist_fn):
+        # Run cluster.create_condensed_dist_matrix() for multiple values
+        # of num_processes; make sure the returned results are all equal
+        result = None
+        for num_processes in [1, 2, 4, 8]:
+            condensed = cluster.create_condensed_dist_matrix(n, dist_fn,
+                    num_processes=num_processes)
+            if result is None:
+                result = condensed
+            else:
+                self.assertTrue(np.array_equal(result, condensed))
+        return result
+
     def test_create_condensed_dist_matrix(self):
         # Have 3 elements: 0 and 1 are similar, 0 and 2 are
         # very dissimilar, and 1 and 2 are similar
@@ -30,7 +43,7 @@ class TestClusterFromMatrix(unittest.TestCase):
         def dist_fn(i, j):
             return dist_matrix_2d[i][j]
 
-        condensed = cluster.create_condensed_dist_matrix(n, dist_fn)
+        condensed = self.create_condensed_dist_matrix(n, dist_fn)
 
         # Use scipy to create a condensed matrix, which is possible
         # since we already have the 2d matrix available
@@ -45,7 +58,7 @@ class TestClusterFromMatrix(unittest.TestCase):
         dists = {(0, 1): 1, (0, 2): 100, (1, 2): 2}
         def dist_fn(i, j):
             return dists[(i, j)]
-        dist_matrix = cluster.create_condensed_dist_matrix(n, dist_fn)
+        dist_matrix = self.create_condensed_dist_matrix(n, dist_fn)
 
         clusters = cluster.cluster_from_dist_matrix(dist_matrix, 10)
         self.assertEqual(clusters, [[0, 1], [2]])
@@ -57,7 +70,7 @@ class TestClusterFromMatrix(unittest.TestCase):
         dists = {(0, 1): 100, (0, 2): 100, (1, 2): 1}
         def dist_fn(i, j):
             return dists[(i, j)]
-        dist_matrix = cluster.create_condensed_dist_matrix(n, dist_fn)
+        dist_matrix = self.create_condensed_dist_matrix(n, dist_fn)
 
         clusters = cluster.cluster_from_dist_matrix(dist_matrix, 10)
         self.assertEqual(clusters, [[1, 2], [0]])
@@ -70,7 +83,7 @@ class TestClusterFromMatrix(unittest.TestCase):
         dists = {(0, 1): 20, (0, 2): 30, (1, 2): 40}
         def dist_fn(i, j):
             return dists[(i, j)]
-        dist_matrix = cluster.create_condensed_dist_matrix(n, dist_fn)
+        dist_matrix = self.create_condensed_dist_matrix(n, dist_fn)
 
         clusters = cluster.cluster_from_dist_matrix(dist_matrix, 10)
         self.assertEqual(sorted(clusters), [[0], [1], [2]])


### PR DESCRIPTION
This PR addresses #24.

Issue #24 gives background and reasons for this feature. In short, [`design.py`](https://github.com/broadinstitute/catch/blob/master/bin/design.py) can be slow when given a large number of highly divergent sequences (e.g., all sequences for all eight segments of influenza A virus). One solution is to cluster input sequences (alignment-free), solve a separate set cover instance on each cluster, and then merge the output probes from each cluster.

This PR adds the argument `--cluster-and-design-separately`. When provided, it produces a signature (or "sketch") of each input sequence using MinHash (similar to what is done in [Mash](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0997-x)) and clusters the sequences by comparing their signatures. Clustering itself can be slow and memory-intensive, but using signatures enables fast pairwise comparison of sequences. Then, it both generates candidate probes independently on each cluster and runs a collection of filters on those candidate probes (typically including [`set_cover_filter`](https://github.com/broadinstitute/catch/blob/master/catch/filter/set_cover_filter.py)) independently on each cluster. It merges the resulting probes (removing exact duplicates), and runs final filters (e.g., [`adapter_filter`](https://github.com/broadinstitute/catch/blob/master/catch/filter/adapter_filter.py)) on the merged set of probes.

Depending on the resource requirements of clustering, this can generally improve runtime and memory usage overall because solving independent, smaller set cover instances requires fewer resources than solving the complete one. One downside is that this can increase the size of the resulting probe set (e.g., if there is homology between input sequences that are placed into different clusters).

This PR also adds the argument `--cluster-from-fragments`, to improve runtime and memory usage on long genomes. When set, this chops input sequences according to some specified fragment length, clusters the fragments, and designs probes independently on each cluster of fragments. The effect might be, for example, that each cluster consists of a gene (or fixed-length piece of a gene). This can help when the input consists of relatively long genomes (e.g., bacterial or DNA virus) because different parts of the genome can be designed, to some extent, independently.