### PR TITLE
Add ability to automatically download sequences for a taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # CATCH &nbsp;&middot;&nbsp; [![Build Status](https://travis-ci.com/broadinstitute/catch.svg?branch=master)](https://travis-ci.com/broadinstitute/catch) [![Coverage Status](https://coveralls.io/repos/broadinstitute/catch/badge.svg?branch=master)](https://coveralls.io/github/broadinstitute/catch?branch=master) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/broadinstitute/catch/pulls) [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 #### Compact Aggregation of Targets for Comprehensive Hybridization
 
-CATCH is a Python package for designing probe sets to use in hybrid capture experiments.
+CATCH is a Python package for designing probe sets to use for nucleic acid capture of diverse sequence.
 
 * **Comprehensive coverage**: CATCH accepts any collection of unaligned sequences &mdash; typically whole genomes of all known genetic diversity of one or more microbial species.
 It designs oligo sequences that guarantee coverage of this diversity, enabling rapid design of exhaustive probe sets for customizable targets.
 * **Compact designs**: CATCH can design with a specified constraint on the number of oligos (e.g., array size).
 It searches a space of probe sets, which may pool many species, to find an optimal design.
-This allows its designs to scale well with known genetic diversity, and also supports cost-effective experiments.
+This allows its designs to scale well with known genetic diversity, and also supports cost-effective applications.
 * **Flexibility**: CATCH supports applications beyond whole genome enrichment, such as differential identification of species.
 It allows blacklisting sequence from the design (e.g., background in microbial enrichment), supports customized models of hybridization, enables weighting the sensitivity for different species, and more.
 <br/>
@@ -65,12 +65,13 @@ git lfs pull
 ```
 
 from inside the `catch` project directory.
+Note that having this data might be helpful, but is not necessary for using CATCH.
 
 ### Testing
 
 CATCH uses Python's `unittest` framework.
 Some of these tests require you to have [downloaded](#downloading-viral-sequence-data) viral sequence data.
-To execute all unit tests, run:
+To execute all tests, run:
 
 ```bash
 python -m unittest discover
@@ -104,7 +105,13 @@ design.py --help
 design.py [dataset] [dataset ...] -o OUTPUT
 ```
 
-Each `dataset` can be a path to a FASTA file. If you [downloaded](#downloading-viral-sequence-data) viral sequence data, it can also simply be a label for one of [550+ viral datasets](./catch/datasets/README.md) (e.g., `human_immunodeficiency_virus_1` or `zika`) distributed as part of this package.
+Each `dataset` can be one of several input formats:
+* A path to a FASTA file.
+* An NCBI taxonomy ID, for which sequences will be automatically downloaded.
+This is specified as `download:TAXID` where TAXID is the taxonomy ID.
+CATCH will fetch all accessions (representing whole genomes) for this taxonomy and download the sequences.
+For viruses, NCBI taxonomy IDs can be found via the [Taxonomy Browser](https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Undef&id=10239).
+* If you [downloaded](#downloading-viral-sequence-data) viral sequence data, a label for one of [550+ viral datasets](./catch/datasets/README.md) (e.g., `human_immunodeficiency_virus_1` or `zika`) distributed as part of this package.
 Each of these datasets includes all available whole genomes (genome neighbors) in [NCBI's viral genome data](https://www.ncbi.nlm.nih.gov/genome/viruses/) for a species that has human as a host, as of Oct. 2018.
 
 The probe sequences are written to OUTPUT in FASTA format.
@@ -181,11 +188,10 @@ We recommend running this multiple times and selecting the output that has the s
 Below is an example of designing probes to target a single taxon.
 
 ```bash
-design.py zika -pl 75 -m 2 -l 60 -e 50 -o zika-probes.fasta --verbose
+design.py download:64320 -pl 75 -m 2 -l 60 -e 50 -o zika-probes.fasta --verbose
 ```
 
-This will design probes that:
-* target whole genomes of Zika virus (`zika`)
+This will download whole genomes of Zika virus (NCBI taxonomy ID [64320](https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=64320)) and design probes that:
 * are 75 nt long (`-pl 75`)
 * capture the entirety of each genome under a model that a probe hybridizes to a region if the longest common substring, up to 2 mismatches (`-m 2`), between a probe and target is at least 60 nt (`-l 60`)
 * assume 50 nt on each side of the hybridization is captured as well (`-e 50`)
@@ -194,7 +200,7 @@ and will save them to `zika-probes.fasta`.
 
 It will provide detailed output during runtime (`--verbose`) and yield about 600 probes.
 Note that using `-l 75` here will run significantly faster, but results in more probes.
-Also, note that the `zika` dataset distributed with CATCH contains 640 genomes, but the input can also be a path to any custom FASTA file.
+Also, note that the input can be `zika` to use the `zika` dataset distributed with CATCH, or a path to any custom FASTA file.
 
 ### Example of running [`pool.py`](./bin/pool.py)
 

--- a/catch/utils/ncbi_neighbors.py
+++ b/catch/utils/ncbi_neighbors.py
@@ -217,7 +217,7 @@ class Neighbor:
                 sorted(self.hosts) == sorted(other.hosts) and
                 self.lineage == other.lineage and
                 self.tax_name == other.tax_name and
-                self.segment == other.segment,
+                self.segment == other.segment and
                 self.metadata == other.metadata)
 
     def __repr__(self):

--- a/catch/utils/ncbi_neighbors.py
+++ b/catch/utils/ncbi_neighbors.py
@@ -1,0 +1,404 @@
+"""Utilities for working with genome neighbors (complete genomes) from NCBI.
+"""
+
+from collections import defaultdict
+import datetime
+import gzip
+import logging
+import random
+import re
+import tempfile
+import time
+import urllib.parse
+import urllib.request
+
+__author__ = 'Hayden Metsky <hayden@mit.edu>'
+
+logger = logging.getLogger(__name__)
+
+
+def urlopen_with_tries(url, initial_wait=5, rand_wait_range=(1, 60),
+        max_num_tries=5):
+    """
+    Open a URL via urllib with repeated tries.
+
+    Often calling urllib.request.urlopen() fails with HTTPError, especially
+    if there are multiple processes calling it. The reason is that NCBI
+    has a cap on the number of requests per unit time, and the error raised
+    is 'HTTP Error 429: Too Many Requests'.
+
+    Args:
+        url: url to open
+        initial_wait: number of seconds to wait in between the first two
+            requests; the wait for each subsequent request doubles in time
+        rand_wait_range: tuple (a, b); in addition to waiting an amount of
+            time that grows exponentially (starting with initial_wait), also
+            wait a random number of seconds between a and b (inclusive).
+            If multiple processes are started simultaneously, this helps to
+            avoid them waiting on the same cycle
+        max_num_tries: maximum number of requests to attempt to make
+
+    Returns:
+        result of urllib.request.urlopen()
+    """
+    num_tries = 0
+    while num_tries < max_num_tries:
+        try:
+            num_tries += 1
+            logger.debug(("Making request to open url: %s"), url)
+            r = urllib.request.urlopen(url)
+            return r
+        except urllib.error.HTTPError:
+            if num_tries == max_num_tries:
+                # This was the last allowed try
+                logger.critical(("Encountered HTTPError %d times (the maximum "
+                    "allowed) when opening url: %s"), num_tries, url)
+                raise
+            else:
+                # Pause for a bit and retry
+                wait = initial_wait * 2**(num_tries - 1)
+                rand_wait = random.randint(*rand_wait_range)
+                total_wait = wait + rand_wait
+                logger.info(("Encountered HTTPError when opening url; "
+                    "sleeping for %d seconds, and then trying again"),
+                    total_wait)
+                time.sleep(total_wait)
+        except:
+            logger.critical(("Encountered unexpected error while opening "
+                "url: %s"), url)
+            raise
+
+
+def ncbi_neighbors_url(taxid):
+    """Construct URL for downloading list of genome neighbors.
+
+    Args:
+        taxid: taxonomic ID to download neighbors for
+
+    Returns:
+        str representing download URL
+    """
+    params = urllib.parse.urlencode({'taxid': taxid, 'cmd': 'download2'})
+    url = 'https://www.ncbi.nlm.nih.gov/genomes/GenomesGroup.cgi?%s' % params
+    return url
+
+
+def fetch_neighbors_table(taxid):
+    """Fetch genome neighbors table from NCBI.
+
+    Args:
+        taxid: taxonomic ID to download neighbors for
+
+    Yields:
+        lines, where each line is from the genome neighbors
+        table and each line is a str
+    """
+    logger.debug(("Fetching table of neighbors for tax %d") % taxid)
+
+    url = ncbi_neighbors_url(taxid)
+    r = urlopen_with_tries(url)
+    raw_data = r.read()
+    for line in raw_data.decode('utf-8').split('\n'):
+        line_rstrip = line.rstrip()
+        if line_rstrip != '':
+            yield line_rstrip
+
+
+def ncbi_influenza_genomes_url():
+    """Construct URL for downloading NCBI influenza genomes database.
+
+    Returns:
+        str representing download URL
+    """
+    url = 'ftp://ftp.ncbi.nih.gov/genomes/INFLUENZA/genomeset.dat.gz'
+    return url
+
+
+def fetch_influenza_genomes_table(species_name):
+    """Fetch influenza genome table from NCBI.
+
+    Args:
+        species_name: filter to keep only lines that contain this species
+            name
+
+    Yields:
+        lines, where each line is from the genome database table and
+        each line is a str
+    """
+    logger.debug(("Fetching table of influenza genomes for species %s") %
+        species_name)
+    species_name_lower = species_name.lower()
+
+    url = ncbi_influenza_genomes_url()
+    r = urlopen_with_tries(url)
+    raw_data = gzip.GzipFile(fileobj=r).read()
+    for line in raw_data.decode('utf-8').split('\n'):
+        line_rstrip = line.rstrip()
+        if line_rstrip != '':
+            if species_name_lower in line_rstrip.lower():
+                yield line_rstrip
+
+
+def ncbi_fasta_download_url(accessions):
+    """Construct URL for downloading FASTA sequence.
+
+    Args:
+        accessions: collection of accessions to download sequences for
+
+    Returns:
+        str representing download URL
+    """
+    ids = ','.join(accessions)
+    # Use safe=',' to not encode ',' as '%2'
+    params = urllib.parse.urlencode({'id': ids, 'db': 'nuccore',
+        'rettype': 'fasta', 'retmode': 'text'}, safe=',')
+    url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?%s' % params
+    return url
+
+
+def fetch_fastas(accessions, batch_size=100, reqs_per_sec=2):
+    """Download sequences for accessions.
+
+    Entrez enforces a limit of ~3 requests per second (or else it
+    will return a 'Too many requests' error); to avoid this, this
+    aims for ~2 requests per second. To use up to 10 requests per second,
+    request an API key from Entrez.
+
+    Args:
+        accessions: collection of accessions to download sequences for
+        batch_size: number of accessions to download in each batch
+        reqs_per_sec: number of requests per second to allow
+
+    Returns:
+        tempfile object containing the sequences in fasta format
+    """
+    logger.debug(("Fetching fasta files for %d accessions") % len(accessions))
+
+    # Make temp file
+    fp = tempfile.NamedTemporaryFile()
+
+    # Download sequences in batches
+    for i in range(0, len(accessions), batch_size):
+        batch = accessions[i:(i + batch_size)]
+        url = ncbi_fasta_download_url(batch)
+        r = urlopen_with_tries(url)
+        raw_data = r.read()
+        for line in raw_data.decode('utf-8').split('\n'):
+            fp.write((line + '\n').encode())
+        time.sleep(1.0/reqs_per_sec)
+
+    # Set position to 0 so it can be re-read
+    fp.seek(0)
+
+    return fp
+
+
+class Neighbor:
+    """Immutable representation of a genome neighbor."""
+
+    def __init__(self, acc, refseq_acc, hosts, lineage, tax_name, segment,
+            metadata={}):
+        self.acc = acc
+        self.refseq_acc = refseq_acc
+        self.hosts = hosts
+        self.lineage = lineage
+        self.tax_name = tax_name
+        self.segment = segment
+        self.metadata = metadata
+
+    def _list_of_attrs(self):
+        """List of all attributes (except the accession)."""
+        return [self.refseq_acc, self.hosts, self.lineage, self.tax_name,
+            self.segment, self.metadata]
+
+    def __eq__(self, other):
+        return (self.acc == other.acc and
+                self.refseq_acc == other.refseq_acc and
+                sorted(self.hosts) == sorted(other.hosts) and
+                self.lineage == other.lineage and
+                self.tax_name == other.tax_name and
+                self.segment == other.segment,
+                self.metadata == other.metadata)
+
+    def __repr__(self):
+        return ';'.join('"' + str(s) + '"' for s in
+            [self.acc] + self._list_of_attrs())
+
+    def __str__(self):
+        return self.acc + ' : ' + ', '.join('"' + str(s) + '"' for s in
+            self._list_of_attrs())
+
+
+def construct_neighbors(taxid):
+    """Construct Neighbor objects for all neighbors of a taxonomic ID.
+
+    Args:
+        taxid: taxonomic ID to download neighbors for
+
+    Returns:
+        list of Neighbor objects
+    """
+    logger.info(("Constructing a list of neighbors for taxid %d") % taxid)
+
+    expected_col_order = ['Representative', 'Neighbor', 'Host',
+        'Selected lineage', 'Taxonomy name', 'Segment name']
+
+    neighbors = []
+    for line in fetch_neighbors_table(taxid):
+        if len(line.strip()) == 0:
+            continue
+
+        ls = line.split('\t')
+
+        if line.startswith('##'):
+            # Header line
+            if line.startswith('## Columns:'):
+                # Verify the columns are as expected
+                col_names = [n.replace('"', '') for n in ls[1:]]
+                if expected_col_order != col_names:
+                    raise Exception(("The order of columns in the neighbor "
+                        "list does not match the expected order"))
+            # Skip the header
+            continue
+
+        refseq_acc = ls[0]
+        acc = ls[1]
+        hosts = ls[2].split(',')
+        lineage = tuple(ls[3].split(','))
+        tax_name = ls[4]
+        segment = ls[5].replace('segment', '').strip()
+
+        neighbor = Neighbor(acc, refseq_acc, hosts, lineage, tax_name, segment)
+        neighbors += [neighbor]
+
+    return neighbors
+
+
+def construct_influenza_genome_neighbors(taxid):
+    """Construct Neighbor objects for all influenza genomes
+
+    According to the README on NCBI's influenza database FTP site:
+    ```
+    The genomeset.dat file contains information for sequences of viruses with a
+    complete set of segments in full-length (or nearly
+    full-length).  Those of the same virus are grouped together (using an internal
+    group ID that is shown in the last column of the file) and separated by an
+    empty line from those of other viruses.
+    ```
+    fetch_influenza_genomes_table() returns genomeset.dat filtered for
+    a given species name.
+
+    According to that same README, the columns are:
+    ```
+    GenBank accession number[tab]Host[tab]Genome segment number or protein name
+    [tab]Subtype[tab]Country[tab]Year/month/date[tab]Sequence length
+    [tab]Virus name[tab]Age[tab]Gender
+    ```
+
+    Args:
+        taxid: taxonomic ID for an influenza species; must be influenza A
+            or B species
+
+    Returns:
+        list of Neighbor objects
+    """
+    logger.info(("Constructing a list of neighbors for influenza species "
+                 "with tax %d") % taxid)
+
+    influenza_species = {11320: 'Influenza A virus',
+                         11520: 'Influenza B virus'}
+    if taxid not in influenza_species:
+        raise ValueError(("Taxid (%d) must be for either influenza A or "
+                          "influenza B virus species") % taxid)
+    species_name = influenza_species[taxid]
+
+    influenza_lineages = {11320: ('Orthomyxoviridae', 'Alphainfluenzavirus',
+                                  'Influenza A virus'),
+                          11520: ('Orthomyxoviridae', 'Betainfluenzavirus',
+                                  'Influenza B virus')}
+    lineage = influenza_lineages[taxid]
+
+    # Construct a pattern to match years in a date (1000--2999)
+    year_p = re.compile('([1-2][0-9]{3})')
+
+    # Determine the current year
+    curr_year = int(datetime.datetime.now().year)
+
+    neighbors = []
+    for line in fetch_influenza_genomes_table(species_name):
+        if len(line.strip()) == 0:
+            continue
+
+        ls = line.split('\t')
+
+        acc = ls[0]
+        hosts = [ls[1]]
+        segment = ls[2]
+        subtype = ls[3]
+        country = ls[4]
+        date = ls[5]
+        seq_len = int(ls[6])
+        name = ls[7]
+
+        # Parse the year
+        year_m = year_p.search(date)
+        if year_m is None:
+            # No year available; skip the sequence
+            continue
+        year = int(year_m.group(1))
+        if year > curr_year:
+            # This year is in the future (probably a typo); skip the sequence
+            continue
+
+        # Construct dict of metadata
+        metadata = {'subtype': subtype, 'country': country, 'year': year,
+                    'seq_len': seq_len}
+
+        # Leave the refseq_acc as None because, in the influenza database,
+        # sequences are not assigned a particular RefSeq
+        neighbor = Neighbor(acc, None, hosts, lineage, name, segment,
+            metadata=metadata)
+        neighbors += [neighbor]
+
+    return neighbors
+
+
+def construct_fasta_for_taxid(taxid, influenza_species={11320, 11520}):
+    """Fetch accessions and a FASTA file for a taxonomy.
+
+    Args:
+        taxid: NCBI taxonomic ID
+        influenza_species: NCBI taxonomic IDs for influenza species; use
+            separate influenza DB for fetching accessions in these taxonomies
+
+    Returns:
+        tempfile object containing the sequences in fasta format
+    """
+    if not isinstance(taxid, int):
+        # Convert taxid to integer
+        try:
+            taxid = int(taxid)
+        except ValueError as error:
+            raise ValueError(("'%s' is not a valid NCBI taxonomic ID; it must "
+                "be an integer") % taxid) from error
+
+    logger.info(("Creating a FASTA file for taxid %d"), taxid)
+
+    # Fetch accessions for taxid
+    if taxid in influenza_species:
+        neighbors = construct_influenza_genome_neighbors(taxid)
+    else:
+        neighbors = construct_neighbors(taxid)
+    if len(neighbors) == 0:
+        raise Exception(("No neighbors were found for taxid %d") % taxid)
+    unique_acc = set(n.acc for n in neighbors)
+    logger.info(("There are %d neighbors, %d of which have unique accessions"),
+            len(neighbors), len(unique_acc))
+
+    # TODO: filter by a given segment, which can be easily done using
+    # the Neighbor objects
+
+    # Fetch a FASTA file of these accessions
+    acc_to_fetch = list(unique_acc)
+    seqs_tf = fetch_fastas(acc_to_fetch)
+    return seqs_tf

--- a/catch/utils/tests/test_ncbi_neighbors.py
+++ b/catch/utils/tests/test_ncbi_neighbors.py
@@ -1,0 +1,64 @@
+"""Tests for ncbi_neighbors module.
+"""
+
+import unittest
+
+from catch.utils import ncbi_neighbors as nn
+
+__author__ = 'Hayden Metsky <hayden@mit.edu>'
+
+
+class TestURLConstruction(unittest.TestCase):
+    """Tests constructing URLs.
+    """
+
+    def test_ncbi_neighbors_url(self):
+        url = nn.ncbi_neighbors_url(123)
+        expected_url = ('https://www.ncbi.nlm.nih.gov/genomes/GenomesGroup'
+            '.cgi?taxid=123&cmd=download2')
+        self.assertEqual(url, expected_url)
+
+    def test_ncbi_fasta_download_url(self):
+        url = nn.ncbi_fasta_download_url(['A123', 'A456', 'B789'])
+        expected_url = ('https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch'
+            '.fcgi?id=A123,A456,B789&db=nuccore&rettype=fasta&retmode=text')
+        self.assertEqual(url, expected_url)
+
+
+class TestConstructNeighbors(unittest.TestCase):
+    """Tests the construct_neighbors() function.
+
+    The function construct_neighbors() calls fetch_neighbors_table(),
+    which makes a request to NCBI. To avoid the request, thsi overrides
+    fetch_neighbors_table() to return a known neighbors table.
+    """
+
+    def setUp(self):
+        self.expected_table_contents = \
+            ("## Comment line 1\n"
+             "## Comment line 2\n"
+             "## Columns:\tRepresentative\tNeighbor\tHost\tSelected lineage\tTaxonomy name\tSegment name\n"
+             "NC_0123\tKY456\tvertebrate,human\tFamilyA,GenusA,SpeciesA\tSpeciesA\tsegment \n"
+             "NC_0456\tAB123\tinvertebrate\tFamilyB,GenusB,SpeciesB\tSpeciesB\tsegment 1\n"
+             "NC_0456\tAB456\tinvertebrate\tFamilyB,GenusB,SpeciesB\tSpeciesB\tsegment 2\n")
+        self.expected_neighbors = [
+            nn.Neighbor('KY456', 'NC_0123', ['vertebrate', 'human'],
+                ('FamilyA', 'GenusA', 'SpeciesA'), 'SpeciesA', ''),
+            nn.Neighbor('AB123', 'NC_0456', ['invertebrate'],
+                ('FamilyB', 'GenusB', 'SpeciesB'), 'SpeciesB', '1'),
+            nn.Neighbor('AB456', 'NC_0456', ['invertebrate'],
+                ('FamilyB', 'GenusB', 'SpeciesB'), 'SpeciesB', '2')
+        ]
+
+        # Override nn.fetch_neighbors_table() to return expected_table_lines,
+        # but keep the real function
+        self.fetch_neighbors_table_real = nn.fetch_neighbors_table
+        nn.fetch_neighbors_table = lambda taxid: self.expected_table_contents.split('\n')
+
+    def test_construct_neighbors(self):
+        neighbors = nn.construct_neighbors(123)
+        self.assertEqual(neighbors, self.expected_neighbors)
+
+    def tearDown(self):
+        # Reset nn.fetch_neighbors_table()
+        nn.fetch_neighbors_table = self.fetch_neighbors_table_real

--- a/catch/utils/tests/test_ncbi_neighbors.py
+++ b/catch/utils/tests/test_ncbi_neighbors.py
@@ -2,6 +2,7 @@
 """
 
 import logging
+import os
 import unittest
 
 from catch.utils import ncbi_neighbors as nn
@@ -105,6 +106,11 @@ class TestConstructNeighborsIntegration(unittest.TestCase):
                 num_with_zika += 1
         self.assertGreaterEqual(num_with_zika, len(neighbors) / 2)
 
+    # Skip this test on Travis CI because it seems to not support calls
+    # to FTP servers; construct_influenza_genome_neighbors() requires an
+    # FTP call
+    @unittest.skipIf("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true",
+            "Skipping test_construct_neighbors_for_influenza() on Travis CI.")
     def test_construct_neighbors_for_influenza(self):
         # Download Influenza A virus neighbors
         neighbors = nn.construct_influenza_genome_neighbors(TAXIDS['IAV'])

--- a/catch/utils/tests/test_ncbi_neighbors.py
+++ b/catch/utils/tests/test_ncbi_neighbors.py
@@ -12,17 +12,24 @@ class TestURLConstruction(unittest.TestCase):
     """Tests constructing URLs.
     """
 
+    def encoded_url_check(self, url, expected_start, expected_fields):
+        url_split = url.split('?')
+        self.assertEqual(url_split[0], expected_start)
+        fields = url_split[1].split('&')
+        self.assertCountEqual(fields, expected_fields)
+
     def test_ncbi_neighbors_url(self):
         url = nn.ncbi_neighbors_url(123)
-        expected_url = ('https://www.ncbi.nlm.nih.gov/genomes/GenomesGroup'
-            '.cgi?taxid=123&cmd=download2')
-        self.assertEqual(url, expected_url)
+        self.encoded_url_check(url,
+            'https://www.ncbi.nlm.nih.gov/genomes/GenomesGroup.cgi',
+            ['taxid=123', 'cmd=download2'])
 
     def test_ncbi_fasta_download_url(self):
         url = nn.ncbi_fasta_download_url(['A123', 'A456', 'B789'])
-        expected_url = ('https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch'
-            '.fcgi?id=A123,A456,B789&db=nuccore&rettype=fasta&retmode=text')
-        self.assertEqual(url, expected_url)
+        self.encoded_url_check(url,
+            'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi',
+            ['id=A123,A456,B789', 'db=nuccore', 'rettype=fasta',
+                'retmode=text'])
 
 
 class TestConstructNeighbors(unittest.TestCase):

--- a/catch/utils/tests/test_ncbi_neighbors.py
+++ b/catch/utils/tests/test_ncbi_neighbors.py
@@ -42,7 +42,7 @@ class TestConstructNeighborsUnit(unittest.TestCase):
     """Unit tests for the construct_neighbors() function.
 
     The function construct_neighbors() calls fetch_neighbors_table(),
-    which makes a request to NCBI. To avoid the request, thsi overrides
+    which makes a request to NCBI. To avoid the request, this overrides
     fetch_neighbors_table() to return a known neighbors table.
     """
 
@@ -75,6 +75,62 @@ class TestConstructNeighborsUnit(unittest.TestCase):
     def tearDown(self):
         # Reset nn.fetch_neighbors_table()
         nn.fetch_neighbors_table = self.fetch_neighbors_table_real
+
+
+class TestConstructInfluenzaGenomeNeighborsUnit(unittest.TestCase):
+    """Unit tests for the construct_influenza_genome_neighbors() function.
+
+    The function construct_influenza_genome_neighbors() calls
+    fetch_influenza_genomes_table(), which makes a request to NCBI. To
+    avoid the request, this overrides fetch_influenza_genomes_table()
+    to return a known genomes table.
+    """
+
+    def setUp(self):
+        self.expected_table_contents = \
+            ("AB123\tHuman\t1\tH1N1\tUSA\t2018\t2300\tInfluenza A virus (A/USA/1/2018(H1N1))\t\t10000\n"
+             "AB456\tHuman\t2\t\tUSA\t2018\t2200\tInfluenza A virus (A/USA/2018)\n"
+             "AB789\tHuman\t3\tH1N1\tUSA\t2018\t2200\tInfluenza A virus (A/USA/2018)\n"
+             "CD123\tHuman\t4\tH1N1\tUSA\t\t2300\tInfluenza A virus (A/USA)\n"
+             "CD456\tHuman\t5\tH1N1\tUSA\t3000\t2200\tInfluenza A virus (A/USA/3000)\n"
+             "CD789\tHuman\t6\tH3N2\tChina\t2015\t2200\tInfluenza A virus (A/China/2015)\n")
+        self.expected_neighbors = [
+            nn.Neighbor('AB123', None, ['Human'],
+                ('Orthomyxoviridae', 'Alphainfluenzavirus', 'Influenza A virus'),
+                "Influenza A virus (A/USA/1/2018(H1N1))", "1",
+                {'subtype': 'H1N1', 'country': 'USA', 'year': 2018,
+                    'seq_len': 2300}),
+            nn.Neighbor('AB456', None, ['Human'],
+                ('Orthomyxoviridae', 'Alphainfluenzavirus', 'Influenza A virus'),
+                "Influenza A virus (A/USA/2018)", "2",
+                {'subtype': '', 'country': 'USA', 'year': 2018,
+                    'seq_len': 2200}),
+            nn.Neighbor('AB789', None, ['Human'],
+                ('Orthomyxoviridae', 'Alphainfluenzavirus', 'Influenza A virus'),
+                "Influenza A virus (A/USA/2018)", "3",
+                {'subtype': 'H1N1', 'country': 'USA', 'year': 2018,
+                    'seq_len': 2200}),
+            nn.Neighbor('CD789', None, ['Human'],
+                ('Orthomyxoviridae', 'Alphainfluenzavirus', 'Influenza A virus'),
+                "Influenza A virus (A/China/2015)", "6",
+                {'subtype': 'H3N2', 'country': 'China', 'year': 2015,
+                    'seq_len': 2200})
+        ]
+
+        # Override nn.fetch_influenza_genomes_table() to return
+        # expected_table_lines, but keep the real function
+        self.fetch_influenza_genomes_table_real = nn.fetch_influenza_genomes_table
+        nn.fetch_influenza_genomes_table = lambda taxid: self.expected_table_contents.split('\n')
+
+    def test_construct_influenza_genome_neighbors(self):
+        # Use 11320 as the taxid, so the function knows the right
+        # Influenza A virus lineage
+        neighbors = nn.construct_influenza_genome_neighbors(11320)
+        self.assertEqual(neighbors, self.expected_neighbors)
+
+    def tearDown(self):
+        # Reset nn.fetch_influenza_genomes_table()
+        nn.fetch_influenza_genomes_table = self.fetch_influenza_genomes_table_real
 
 
 class TestConstructNeighborsIntegration(unittest.TestCase):


### PR DESCRIPTION
This PR adds an option to specify input in the form of an NCBI taxonomy ID. When specified this way, CATCH will fetch all accessions (genome neighbors) for the taxonomy, download sequences of those accessions, and use them as input.

This adds the `ncbi_neighbors` module to make calls to NCBI's Entrez system. To use this feature, the format for input datasets to [`design.py`](https://github.com/broadinstitute/catch/blob/master/bin/design.py) is `download:TAXID`. TAXID is an NCBI taxonomy ID. This PR also updates the README to describe this feature and changes the main example to use it.