### PR TITLE
Fix --cluster-from-fragments bug with long fragment length

### DIFF
--- a/catch/genome.py
+++ b/catch/genome.py
@@ -83,7 +83,7 @@ class Genome:
                 if include_full_end and len(fragment) < fragment_length:
                     # This is at the end of seq; instead, use the last
                     # fragment_length nt
-                    yield seq[(len(seq) - fragment_length):]
+                    yield seq[max(0, len(seq) - fragment_length):]
                 else:
                     yield fragment
 

--- a/catch/tests/test_genome.py
+++ b/catch/tests/test_genome.py
@@ -92,6 +92,13 @@ class TestGenome(unittest.TestCase):
                 OrderedDict([('0', 'ATC'), ('1', 'GTT'), ('2', 'TAA')]))
         self.assertEqual(broken, expected_genome)
 
+    def test_break_into_fragments_from_one_seq_with_full_end_and_long_fragment(self):
+        genome_one = genome.Genome.from_one_seq('ATCGTTAA')
+        broken = genome_one.break_into_fragments(12, include_full_end=True)
+        expected_genome = genome.Genome.from_chrs(
+                OrderedDict([('0', 'ATCGTTAA')]))
+        self.assertEqual(broken, expected_genome)
+
     def test_break_into_fragments_from_chrs(self):
         genome_two_chrs = genome.Genome.from_chrs(
                 OrderedDict([("chr1", 'ATCGTTAA'), ("chr2", 'AATTCCGGG')]))


### PR DESCRIPTION
This fixes a bug in `genome.Genome.break_into_fragments()` when `--cluster-from-fragments` is specified with a `fragment_length` that is longer than the sequence length and `include_full_end` is True. In this case, `break_from_fragments()` ought to yield `seq` in its entirety. However, in this case, `len(seq)-fragment_length` is negative. `seq[len(seq)-fragment_length]` would pull out the last `len(seq)-fragment_length` nt of seq. If `fragment_length` is sufficiently long (>=2\*len(seq)), the result would be fine: it would yield `seq` in its entirety, as desired. However, if `fragment_length` is >len(seq) but <2\*len(seq), it would not yield all of `seq`.

This is meant to address Issue #37.