### PR TITLE
Improve handling of the case when there are no candidate probes

### DIFF
--- a/catch/filter/probe_designer.py
+++ b/catch/filter/probe_designer.py
@@ -174,6 +174,16 @@ class ProbeDesigner:
                         allow_small_seqs=self.allow_small_seqs,
                         seq_length_to_skip=self.seq_length_to_skip)
 
+        if len(candidates) == 0:
+            # There are no candidate probes, possibly because all input
+            # sequences in genomes were skipped
+            logger.warning(("There are no candidate probes for a grouping of "
+                "genomes; it is possible that --small-seq-skip or "
+                "--small-seq-min are incompatible with the input sequence "
+                "lengths, especially if --cluster-and-design-separately is "
+                "set small. Skipping this grouping and returning no probes."))
+            return ([], [])
+
         probes = self._pass_through_filters(candidates, genomes, filters)
         return (candidates, probes)
 

--- a/catch/probe.py
+++ b/catch/probe.py
@@ -693,6 +693,9 @@ class SharedKmerProbeMap:
             ValueError if k-mers have different lengths or the kmer_probe_map
             does not include positions
         """
+        if len(kmer_probe_map) == 0:
+            raise ValueError(("kmer_probe_map is empty"))
+
         # Find the k-mer length k, check that all k-mers in the map are
         # of length k, and check that the k-mers in the map come with
         # positions


### PR DESCRIPTION
There may be some valid cases where there are no candidate probes. For
example, if genomes are clustered and `--small-seq-skip` is set, one
cluster may contain short genomes that are all skipped -- and thus and
the cluster has no genomes and therefore no candidate probes. This will
cause an error because `kmer_probe_map` would be empty. This PR allows
clusters/groupings of genomes to have no candidate probes, and for CATCH
to proceed in that case.