### PR TITLE
Fix initial guess to be within bounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: python
 
 python:
- - "3.5"
- - "3.6"
- - "3.7"
- - "3.8"
- - "3.9"
+ - 3.5
+ - 3.6
+
+# Python 3.7 requires dist: xenial and sudo: true
+# (see https://github.com/travis-ci/travis-ci/issues/9815#issue-336465122)
+matrix:
+ include:
+  - python: 3.7
+    dist: xenial
+    sudo: true
 
 cache:
  directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
 language: python
 
 python:
- - 3.5
- - 3.6
-
-# Python 3.7 requires dist: xenial and sudo: true
-# (see https://github.com/travis-ci/travis-ci/issues/9815#issue-336465122)
-matrix:
- include:
-  - python: 3.7
-    dist: xenial
-    sudo: true
+ - "3.5"
+ - "3.6"
+ - "3.7"
+ - "3.8"
+ - "3.9"
 
 cache:
  directories:

--- a/catch/pool/param_search.py
+++ b/catch/pool/param_search.py
@@ -710,11 +710,11 @@ def higher_dimensional_search(param_names, probe_counts, max_total_count,
     # Setup the loss function, parameter bounds, and make an initial guess
     loss_fn = _make_loss_fn(probe_counts, max_total_count, loss_coeffs,
         dataset_weights, interp_fn_type='nd')
-    x0 = _make_initial_guess(probe_counts, None, num_params)
+    bounds = _make_param_bounds_nd(probe_counts)
+    x0 = _make_initial_guess(probe_counts, bounds, num_params)
 
     # Find the optimal parameter values, interpolating probe counts
     # for parameter values between what have been explicitly calculated
-    bounds = _make_param_bounds_nd(probe_counts)
     x_sol = _optimize_loss(probe_counts, loss_fn, bounds, x0,
         interp_fn_type='nd')
 


### PR DESCRIPTION
The initial guess for the higher dimensional search could fall outside
of the parameter bounds. This was causing the error
```
ValueError: `x0` violates bound constraints.
```
by fmin_tnc() in integration tests of param_search.

This commit forces the initial guess to be within the parameter bounds.