### PR TITLE
Improve hash function in MinHash family

### DIFF
--- a/catch/filter/near_duplicate_filter.py
+++ b/catch/filter/near_duplicate_filter.py
@@ -156,7 +156,8 @@ class NearDuplicateFilterWithMinHash(NearDuplicateFilter):
                 that this is *not* the same as self.k
         """
         super().__init__(k=3)
-        self.lsh_family = lsh.MinHashFamily(kmer_size)
+        self.lsh_family = lsh.MinHashFamily(kmer_size,
+                use_fast_str_hash=True) # safe as long as not parallelized
         self.dist_thres = dist_thres
 
         def jaccard_dist(a, b):

--- a/catch/utils/tests/test_lsh.py
+++ b/catch/utils/tests/test_lsh.py
@@ -1,6 +1,7 @@
 """Tests for lsh module.
 """
 
+import logging
 import random
 import unittest
 
@@ -118,6 +119,9 @@ class TestMinHashFamilySignatures(unittest.TestCase):
     """
     
     def setUp(self):
+        # Disable logging
+        logging.disable(logging.WARNING)
+
         # Set a random seed so hash functions are always the same
         random.seed(0)
 
@@ -125,6 +129,17 @@ class TestMinHashFamilySignatures(unittest.TestCase):
 
     def test_identical(self):
         a = 'ATCGATATGGGCACTGCTAT'
+        b = str(a)
+
+        # Identical strings should yield the same signature, for the same
+        # hash function
+        for i in range(10):
+            h = self.family.make_h()
+            self.assertEqual(h(a), h(b))
+            self.assertEqual(self.family.estimate_jaccard_dist(h(a), h(b)), 0.0)
+
+    def test_identical_with_short_sequences(self):
+        a = 'ATCGA'
         b = str(a)
 
         # Identical strings should yield the same signature, for the same
@@ -161,6 +176,10 @@ class TestMinHashFamilySignatures(unittest.TestCase):
             if self.family.estimate_jaccard_dist(h(a), h(b)) > 0.5:
                 num_far += 1
         self.assertGreaterEqual(num_far, 80)
+
+    def tearDown(self):
+        # Re-enable logging
+        logging.disable(logging.NOTSET)
 
 
 class TestHammingHashConcatenation(unittest.TestCase):


### PR DESCRIPTION
This PR makes several small changes designed to improve the behavior of the MinHash family's hash functions:

- Changes their inner function, used for strings (k-mers), from Adler-32 to md5 [1527bec]
- Updates the construction of sequence signatures to tolerate sequences that were previously considered too short (i.e., too few k-mers for the signature) [fc6e8a6]