### PR TITLE
Fix bugs in edge cases handling small input

### DIFF
--- a/catch/filter/set_cover_filter.py
+++ b/catch/filter/set_cover_filter.py
@@ -386,6 +386,13 @@ class SetCoverFilter(BaseFilter):
             of interval.IntervalSet -- to save space and it should be
             coverted to an interval.IntervalSet when needed.)
         """
+        # Check if there are no candidate probes; this could happen, e.g.,
+        #   if there is one short target sequence that has a string of Ns
+        # In this case, kmer_probe_map will be empty, leading to errors,
+        #   so avoid that by simply returning an empty dict
+        if len(candidate_probes) == 0:
+            return dict()
+
         logger.info("Building map from k-mers to probes")
         kmer_probe_map = probe.SharedKmerProbeMap.construct(
             probe.construct_kmer_probe_map_to_find_probe_covers(

--- a/catch/filter/tests/test_set_cover_filter.py
+++ b/catch/filter/tests/test_set_cover_filter.py
@@ -575,6 +575,15 @@ class TestSetCoverFilter(unittest.TestCase):
         output_probes = list(set(p for i in output_probes for p in i)) # flatten
         self.assertEqual(set(output_probes), {probe.Probe.from_str('AAABCB')})
 
+    def test_filter_empty_input(self):
+        target_genomes = [['ACGT']]
+        target_genomes = self.convert_target_genomes(target_genomes)
+        f = scf.SetCoverFilter(0, 0)
+        output_probes = f._filter([[]], target_genomes)
+        self.assertEqual(output_probes, [[]])
+        output_probes = f.filter([[]], target_genomes, input_is_grouped=True)
+        self.assertEqual(output_probes, [[]])
+
     def tearDown(self):
         # Re-enable logging
         logging.disable(logging.NOTSET)

--- a/catch/utils/cluster.py
+++ b/catch/utils/cluster.py
@@ -204,6 +204,11 @@ def cluster_hierarchically_from_dist_matrix(dist_matrix, threshold):
         (whose pairwise distances are indexed in dist) in the i'th
         cluster, in sorted order by descending cluster size
     """
+    # An empty condensed distance matrix can occur when there is n=1
+    #   observation; in this case, just return a single cluster with it
+    if len(dist_matrix) == 0:
+        return [[0]]
+
     linkage = hierarchy.linkage(dist_matrix, method='average')
     clusters = hierarchy.fcluster(linkage, threshold, criterion='distance')
 

--- a/catch/utils/tests/test_cluster.py
+++ b/catch/utils/tests/test_cluster.py
@@ -3,6 +3,7 @@
 
 import logging
 import unittest
+import warnings
 
 import numpy as np
 import scipy
@@ -87,6 +88,22 @@ class TestClusterFromMatrix(unittest.TestCase):
 
         clusters = cluster.cluster_hierarchically_from_dist_matrix(dist_matrix, 10)
         self.assertEqual(sorted(clusters), [[0], [1], [2]])
+
+    def test_cluster_hierarchically_from_dist_matrix_one_element(self):
+        # Have 1 element
+        n = 1
+        dists = {}
+        def dist_fn(i, j):
+            return dists[(i, j)]
+
+        # Ignore an expected warning when making a distance matrix from n=1
+        # observation
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=RuntimeWarning)
+            dist_matrix = self.create_condensed_dist_matrix(n, dist_fn)
+
+        clusters = cluster.cluster_hierarchically_from_dist_matrix(dist_matrix, 10)
+        self.assertEqual(sorted(clusters), [[0]])
 
     def tearDown(self):
         # Re-enable logging

--- a/catch/utils/tests/test_set_cover.py
+++ b/catch/utils/tests/test_set_cover.py
@@ -145,7 +145,7 @@ class TestSetCoverApprox(unittest.TestCase):
     def test_no_elements(self):
         input = {}
         self.assertEqual(sc.approx(input), set([]))
-        inptut = {0: set([])}
+        input = {0: set([])}
         self.assertEqual(sc.approx(input), set([]))
 
     def test_one_element(self):
@@ -680,6 +680,16 @@ class TestSetCoverApproxMultiuniverse(unittest.TestCase):
         # (e.g., test that it's less than 0.01)
         self.assertLess(np.median(weight_fracs), 0.01)
         return outputs
+
+    def test_no_elements(self):
+        input = {}
+        self.assertEqual(sc.approx_multiuniverse(input), set())
+        input = {0: {0: set()}}
+        self.assertEqual(sc.approx_multiuniverse(input), set())
+
+    def test_one_element(self):
+        input = {0: {0: set([1])}}
+        self.assertEqual(sc.approx_multiuniverse(input), {0})
 
     def tearDown(self):
         # Re-enable logging


### PR DESCRIPTION
This makes several fixes to bugs that had caused CATCH to crash in edge cases:

* When clustering sequences using the hierarchical method and there is just 1 input sequence. See 00369e6
* When solving a set cover instance on a cluster/grouping that has no candidate probes (e.g., a short sequence with a string of Ns). See f96817b