### PR TITLE
Fix crash on macOS with Python 3.8+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ cache:
   - $HOME/virtualenv
 
 install:
- - pip install -r requirements.txt
- - pip install coveralls[yaml] nose-cov
+ - pip3 install -r requirements.txt
+ - pip3 install coveralls[yaml] nose-cov
  - python setup.py install --force
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ jobs:
       os: linux
       dist: focal
       python: 3.9
-    - name: "Python on macOS"
-      os: osx
-      language: generic # needed for Travis on macOS
-      osx_image: xcode13.4 # macOS 12.4
-      before_install:
-        - python3 --version
+#    - name: "Python on macOS"
+#      os: osx
+#      language: generic # needed for Travis on macOS
+#      osx_image: xcode13.4 # macOS 12.4
+#      before_install:
+#        - python3 --version
 
 cache:
  directories:
@@ -23,8 +23,8 @@ cache:
 
 install:
  - pip3 install --upgrade pip
- - pip3 install -r requirements.txt || sudo pip3 install -r requirements.txt # try sudo, if needed on macOS
- - pip3 install coveralls[yaml] nose-cov || sudo pip3 install coveralls[yaml] nose-cov
+ - pip3 install -r requirements.txt
+ - pip3 install coveralls[yaml] nose-cov 
  - python setup.py install --force || python3 setup.py install --force # try python, then python3
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: python
 
-python:
- - 3.8
- - 3.9
- - "3.10"
+jobs:
+  include:
+    - os: linux
+      dist: focal
+      python: 3.8
+    - os: linux
+      dist: focal
+      python: 3.9
+    - os: linux
+      dist: focal
+      python: "3.10"
 
 cache:
  directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ jobs:
     - os: linux
       dist: focal
       python: 3.9
-    - os: linux
-      dist: focal
-      python: "3.10"
 
 cache:
  directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
   - $HOME/virtualenv
 
 install:
- - pip3 install -r requirements.txt
+ - pip3 install -r requirements.txt || sudo pip3 install -r requirements.txt # try sudo, if needed on macOS
  - pip3 install coveralls[yaml] nose-cov
  - python setup.py install --force || python3 setup.py install --force # try python, then python3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
       python: 3.9
     - os: osx
       language: generic
-      python: 3.8
+      env: TOXENV=py38
 
 cache:
  directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ jobs:
       dist: focal
       python: 3.9
     - os: osx
-      language: generic
-      env: TOXENV=py38
+      language: generic # needed for Travis on macOS
+      osx_image: xcode13.4 # macOS 12.4
 
 cache:
  directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,9 @@ cache:
   - $HOME/virtualenv
 
 install:
+ - pip3 install --upgrade pip
  - pip3 install -r requirements.txt || sudo pip3 install -r requirements.txt # try sudo, if needed on macOS
- - pip3 install coveralls[yaml] nose-cov
+ - pip3 install coveralls[yaml] nose-cov || sudo pip3 install coveralls[yaml] nose-cov
  - python setup.py install --force || python3 setup.py install --force # try python, then python3
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,20 @@ language: python
 
 jobs:
   include:
-    - os: linux
+    - name: "Python 3.8 on Focal Linux"
+      os: linux
       dist: focal
       python: 3.8
-    - os: linux
+    - name: "Python 3.9 on Focal Linux"
+      os: linux
       dist: focal
       python: 3.9
-    - os: osx
+    - name: "Python on macOS"
+      os: osx
       language: generic # needed for Travis on macOS
       osx_image: xcode13.4 # macOS 12.4
+      before_install:
+        - python3 --version
 
 cache:
  directories:
@@ -19,7 +24,7 @@ cache:
 install:
  - pip3 install -r requirements.txt
  - pip3 install coveralls[yaml] nose-cov
- - python setup.py install --force
+ - python setup.py install --force || python3 setup.py install --force # try python, then python3
 
 script:
  - nosetests -v --with-xunit --with-coverage --cover-inclusive --cover-branches --cover-package catch

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ jobs:
     - os: linux
       dist: focal
       python: 3.9
+    - os: osx
+      language: generic
+      python: 3.8
 
 cache:
  directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
  - 3.8
  - 3.9
+ - "3.10"
 
 cache:
  directories:

--- a/bin/analyze_probe_coverage.py
+++ b/bin/analyze_probe_coverage.py
@@ -4,6 +4,7 @@
 import argparse
 import importlib
 import logging
+import multiprocessing
 import os
 
 from catch import coverage_analysis
@@ -46,6 +47,24 @@ def main(args):
     if args.max_num_processes:
         probe.set_max_num_processes_for_probe_finding_pools(
             args.max_num_processes)
+
+    # On macOS, starting with Python 3.8, new processes begin following the
+    #   spawn behavior rather than fork; apparently, forking processes in
+    #   macOS can cause crashes, but CATCH with older versions of
+    #   Python has not experienced those issues. Parts of CATCH --
+    #   especially the pools in the `probe` module -- are written to follow
+    #   the fork behavior, where child processes inherit memory from their
+    #   parent. When spawning processes, those child processes do not inherit
+    #   memory, and CATCH crashes because the global variables are not
+    #   accessible.
+    # See https://github.com/python/cpython/issues/84112 for another user
+    #   reporting the change in Python 3.8.
+    # A quick fix is to simply change the behavior, on macOS, to fork
+    #   processes. This is implemented below. A longer term, more appropriate
+    #   fix might be to change the global variables accessed by children to
+    #   use multiprocessing.shared_memory.SharedMemory objects.
+    if os.uname().sysname == 'Darwin':
+        multiprocessing.set_start_method('fork')
 
     # Read the FASTA file of probes
     fasta = seq_io.read_fasta(args.probes_fasta)

--- a/bin/design.py
+++ b/bin/design.py
@@ -226,6 +226,25 @@ def main(args):
         base_filter.set_max_num_processes_for_filter_over_groupings(
             args.max_num_processes)
 
+    # On macOS, starting with Python 3.8, new processes begin following the
+    #   spawn behavior rather than fork; apparently, forking processes in
+    #   macOS can cause crashes, but CATCH with older versions of
+    #   Python has not experienced those issues. Parts of CATCH --
+    #   especially the pools in the `probe` module -- are written to follow
+    #   the fork behavior, where child processes inherit memory from their
+    #   parent. When spawning processes, those child processes do not inherit
+    #   memory, and CATCH crashes because the global variables are not
+    #   accessible.
+    # See https://github.com/python/cpython/issues/84112 for another user
+    #   reporting the change in Python 3.8.
+    # A quick fix is to simply change the behavior, on macOS, to fork
+    #   processes. This is implemented below. A longer term, more appropriate
+    #   fix might be to change the global variables accessed by children to
+    #   use multiprocessing.shared_memory.SharedMemory objects.
+    if os.uname().sysname == 'Darwin':
+        logger.debug(("Setting multiprocessing start method to 'fork'"))
+        multiprocessing.set_start_method('fork')
+
     # Raise exceptions or warn based on use of adapter arguments
     if args.add_adapters:
         if not (args.adapter_a or args.adapter_b):


### PR DESCRIPTION
This fixes #49. See 2a548e8.

This PR also makes some changes to Travis CI's configuration file in an attempt to add testing on macOS, but reverts those changes. Getting macOS testing to work, especially with recent version of Python (3.8+), seems like it will be a more complicated undertaking than it might be worth.

