### PR TITLE
Add heuristic to decide which clustering method to use

### DIFF
--- a/bin/design.py
+++ b/bin/design.py
@@ -809,7 +809,7 @@ def init_and_parse_args(args_type : _ARGS_TYPES):
               "input and sequences will not be grouped by genome, and "
               "differential identification is not supported"))
     parser.add_argument('--cluster-and-design-separately-method',
-        choices=['simple', 'hierarchical'], default='simple',
+        choices=['choose', 'simple', 'hierarchical'], default='choose',
         help=("(Optional) Method for clustering input sequences, which is "
               "only used if --cluster-and-design-separately is set. If "
               "'simple', clusters are connected components of a graph in "
@@ -818,7 +818,12 @@ def init_and_parse_args(args_type : _ARGS_TYPES):
               "the value CLUSTER_AND_DESIGN_SEPARATELY. If 'hierarchical', "
               "clusters are determined by agglomerative hierarchical "
               "clustering and the the value CLUSTER_AND_DESIGN_SEPARATELY "
-              "is the inter-cluster distance threshold to merge clusters."))
+              "is the inter-cluster distance threshold to merge clusters. "
+              "If 'choose', use a heuristic to decide among 'simple' and "
+              "'hierarchical' based on the input. This option can affect "
+              "performance and the heuristic does not always make the right "
+              "choice, so trying both choices 'simple' and 'hierarchical' "
+              "can sometimes be helpful if needed."))
     default_cluster_from_fragments = {'basic': None, 'large': 50000}
     parser.add_argument('--cluster-from-fragments',
         type=int,


### PR DESCRIPTION
The comment added by this commit to `probe_designer` details a problem with the recently-introduced default method for clustering input sequences (`simple`; see d6ef14e). The problem occurs on long genomes (e.g., bacterial) when also breaking the genomes into fragments and clustering those.

This commit introduces a crude heuristic to select whether to use the newer `simple` method (which finds connected components) or the older, most resource-intensive `hierarchical` method (which uses agglomerative hierarchical clustering). `hierarchical` avoids the problem.

The argument `--cluster-and-design-separately-method` now has a new choice, `choose`, to use the heuristic to decide the method, and `choose` is the default setting for that argument.

This change will likely improve performance with out-of-the-box usage (e.g., running `design_large.py`) on long genomes, including bacterial genomes, following d6ef14e, which made `simple` be the default clustering method.